### PR TITLE
Fix pauseCount updating on pause()

### DIFF
--- a/src/BattleManager/regularbattlescene.cpp
+++ b/src/BattleManager/regularbattlescene.cpp
@@ -273,7 +273,7 @@ bool RegularBattleScene::isPlayer(int spot) const
 
 void RegularBattleScene::pause()
 {
-    pauseCount =+ 1;
+    pauseCount += 1;
     baseClass::pause();
 }
 


### PR DESCRIPTION
clang caught this and it seems to be a bug.
