### PR TITLE
Script Functions for tray icon

### DIFF
--- a/src/Teambuilder/client.cpp
+++ b/src/Teambuilder/client.cpp
@@ -2785,7 +2785,7 @@ void Client::trayMessage(const QString &title, const QString &message)
     MainEngine::inst->showMessage(title, message);
 }
 
-bool Client::windowActive () {
+bool Client::windowActive() {
     return qApp->activeWindow();
 }
 

--- a/src/Teambuilder/client.h
+++ b/src/Teambuilder/client.h
@@ -167,7 +167,7 @@ public slots:
     void printChannelMessage(const QString &mess, int channel, bool html);
 
     void trayMessage(const QString &title, const QString &message);
-    bool windowActive ();
+    bool windowActive();
 
     /* sends what's in the line edit */
     void sendText();


### PR DESCRIPTION
Dr. Fuji gave me the idea for this!
client.trayMessage(QString title, QString message) lets you make a popup on the tray icon that displays a message with a title.
client.windowActive() returns true or false depending on whether or not the client is active (So scripters can make sure the tray message only appears if the client is inactive)
