### PR TITLE
Add parameter ignore(default:false) to playerLogin

### DIFF
--- a/src/Teambuilder/client.cpp
+++ b/src/Teambuilder/client.cpp
@@ -2264,22 +2264,25 @@ QString Client::announcement()
     return server_announcement->document()->toPlainText();
 }
 
-void Client::playerLogin(const PlayerInfo& p, const QStringList &tiers)
+void Client::playerLogin(const PlayerInfo& p, const QStringList &tiers, bool ignore=false)
 {
-    cleanData();
-    _mid = p.id;
-    mynick = p.name;
-    myplayersinfo[p.id] = p;
-    mynames[p.name] = p.id;
+    if (!ignore) { 
+        cleanData();
+        _mid = p.id;
+        mynick = p.name;
+        myplayersinfo[p.id] = p;
+        mynames[p.name] = p.id;
 
-    mylowernames[p.name.toLower()] = p.id;
+        mylowernames[p.name.toLower()] = p.id;
 
-    playerReceived(p);
-    tiersReceived(tiers);
+        playerReceived(p);
+        tiersReceived(tiers);
 
-    /* If it's us, we know we've logged in */
-    if (p.id == ownId())
-        loggedIn = true;
+        /* If it's us, we know we've logged in */
+        if (p.id == ownId()) {
+            loggedIn = true;
+        }
+    }
 }
 
 void Client::tiersReceived(const QStringList &tiers)


### PR DESCRIPTION
So that client scripts can call all slots created by other client scripts (.connect) without touching anything.

This will be extremely useful for this: https://raw.github.com/TheUnknownOne/PO-Client-Tools/master/scriptLoader.js (emitSignals function)

``` javascript
emitSignals: function () { // fixes scripts that use signals
            var net = client.network(); // there might be others that need to be emitted...
            
            //if (loggedIn) { // PO is broken :[
                //net.playerLogin(/*{}*/playerLoginArgs, client.getTierList()); // <-- this would have , true to completely fix this problem
            //}
            
            // instead using scriptLoader.loginHandlers.. Hoping people will use this
            scriptLoader.loginHandlers.forEach(function (value, index, array) {
                value(playerLoginArgs, sys.getTierList(), 1); // return 1 as 3rd argument to indicate that it was called by ScriptLoader
            });
            
            scriptLoader.loginHandlers = [];
            
            net.serverNameReceived(serverName);
            net.announcement(announcement);
            
        },
```
