### PR TITLE
Fixing po:ignore and po:watchplayer and adding po:info to allow clicking of a link to a player's info

### DIFF
--- a/src/Teambuilder/channel.cpp
+++ b/src/Teambuilder/channel.cpp
@@ -172,7 +172,7 @@ void Channel::anchorClicked(const QUrl &url)
                 int pid = client->id(player);
                 client->seeInfo(pid);
             } else {
-                client->ignore(id);
+                client->seeInfo(id);
             }
         }
     } else {


### PR DESCRIPTION
http://pokemon-online.eu/forums/showthread.php?18291-Chat-Option&p=249009#post249009
This gave me the idea. Basically you can just use scripts to make the names clickable links to challenges instead :3 (You can use styling etc to remove the underline and change colour to the player's name).
I'd take a screenshot of it in action, but it's sort of hard to see...
