### PR TITLE
os() function

### DIFF
--- a/src/ClientScripting/scriptengine.cpp
+++ b/src/ClientScripting/scriptengine.cpp
@@ -1256,3 +1256,7 @@ bool ScriptEngine::validColor(const QString &color)
 
     return colorName.isValid();
 }
+
+QScriptValue ScriptEngine::os() {
+    return OS;
+}

--- a/src/ClientScripting/scriptengine.h
+++ b/src/ClientScripting/scriptengine.h
@@ -130,6 +130,9 @@ public:
     Q_INVOKABLE bool isSafeScripts();
     Q_INVOKABLE bool showingWarnings();
 
+    // Returns the player's operating system (windows, mac, linux)
+    Q_INVOKABLE QScriptValue os();
+
     Q_INVOKABLE void hostName(const QString &ip, const QScriptValue &function);
 
     /* Save vals using the QSettings (persistent vals, that stay after the shutdown of the server */

--- a/src/Server/scriptengine.cpp
+++ b/src/Server/scriptengine.cpp
@@ -2614,6 +2614,10 @@ QScriptValue ScriptEngine::avatar(int playerId)
     return myserver->player(playerId)->avatar();
 }
 
+QScriptValue ScriptEngine::os() {
+    return OS;
+}
+
 QScriptValue ScriptEngine::os(int playerId)
 {
     if (!loggedIn(playerId)) {

--- a/src/Server/scriptengine.h
+++ b/src/Server/scriptengine.h
@@ -257,6 +257,11 @@ public:
     Q_INVOKABLE QScriptValue info(int playerId);
     Q_INVOKABLE void changeAvatar(int playerId, quint16 avatarId);
     Q_INVOKABLE QScriptValue avatar(int playerId);
+
+    // Overloaded function os.
+    // First (no parameters) returns the server's os.
+    // Second (with a param) returns a player's os.
+    Q_INVOKABLE QScriptValue os();
     Q_INVOKABLE QScriptValue os(int playerId);
 
     Q_INVOKABLE QScriptValue pokemon(int num);


### PR DESCRIPTION
For client & server.

Server's version is an overloaded version. It expects no parameters.

Fixes #233
