### PR TITLE
Confuse / Baton Pass Fix

### DIFF
--- a/src/Server/battlebase.cpp
+++ b/src/Server/battlebase.cpp
@@ -1825,7 +1825,7 @@ void BattleBase::healStatus(int player, int status)
 void BattleBase::healConfused(int player)
 {
     poke(player).removeStatus(Pokemon::Confused);
-    pokeMemory(player)["ConfusedCount"] = 0;
+    pokeMemory(player).remove("ConfusedCount");
 }
 
 bool BattleBase::isConfused(int player)


### PR DESCRIPTION
The confuse counter wasn't being reset when confusion was, so Baton Pass would inflict confusion when passed even though it was cured.
