### PR TITLE
Jaboca/Rowap incorrect recoil effect

### DIFF
--- a/src/Server/berries.cpp
+++ b/src/Server/berries.cpp
@@ -415,7 +415,7 @@ struct BMBerryRecoil : public BM
         }
         b.eatBerry(s);
         b.sendBerryMessage(12,s,0,t);
-        b.inflictDamage(t, b.poke(t).lifePoints()/8,s,false);
+        b.inflictDamage(t, b.poke(t).totalLife()/8,s,false);
     }
 };
 


### PR DESCRIPTION
Used to be 12.5% of current HP, should be 12.5% of maximum HP
