### PR TITLE
Added bool ItemInfo::isJewel

### DIFF
--- a/src/PokemonInfo/pokemoninfo.cpp
+++ b/src/PokemonInfo/pokemoninfo.cpp
@@ -2382,6 +2382,11 @@ bool ItemInfo::isDrive(int itemnum)
     return itemnum == Item::DouseDrive || itemnum == Item::BurnDrive || itemnum == Item::ChillDrive || itemnum == Item::ShockDrive;
 }
 
+bool ItemInfo::isJewel(int itemnum)
+{
+    return itemnum == Item::NormalJewel || itemnum == Item::FightJewel || itemnum == Item::SteelJewel || itemnum == Item::PsychicJewel || itemnum == Item::DarkJewel || itemnum == Item::FireJewel || itemnum == Item::WaterJewel || itemnum == Item::ElectricJewel || itemnum == Item::IceJewel || itemnum == Item::FlightJewel || itemnum == Item::PoisonJewel || itemnum == Item::GhostJewel || itemnum == Item::Bugjewel || itemnum == Item::GrassJewel || itemnum == Item::RockJewel || itemnum == Item::EarthJewel || itemnum == Item::DragonJewel;
+}
+
 bool ItemInfo::isMail(int itemnum)
 {
     return (itemnum >= 214 && itemnum <= 226);


### PR DESCRIPTION
For possible fix for Fling where it needs to fail if there is a jewel. Also, just in case a 6th gen move acts differently with Jewels, then we have them as a collection instead of having to type out each individual one.
