### PR TITLE
Prankster + Trick Room Fix

### DIFF
--- a/src/Server/abilities.cpp
+++ b/src/Server/abilities.cpp
@@ -1481,7 +1481,7 @@ struct AMMischievousHeart : public AM
     }
 
     static void pc(int s, int, BS &b) {
-        if (tmove(b,s).power == 0 && tmove(b,s).priority == 0)
+        if (tmove(b,s).power == 0)
             tmove(b,s).priority += 1;
     }
 };


### PR DESCRIPTION
Prankster was incorrectly only adding priority for moves with 0 priority.
