### PR TITLE
Soak Fixes

### DIFF
--- a/src/Server/moves.cpp
+++ b/src/Server/moves.cpp
@@ -5474,7 +5474,7 @@ struct MMSoak : public MM {
     }
 
     static void daf(int s, int t, BS &b) {
-        if (fpoke(b, t).type1 == Pokemon::Water && fpoke(b, t).type2 == Pokemon::Curse)
+        if (b.ability(t) == Ability::Multitype)
             fturn(b,s).add(TM::Failed);
     }
 


### PR DESCRIPTION
Soak doesn't affect pokemon with multitype. It also succeeds against pure water types, which wasn't the mechanic before. I tested both of these in game myself.
