### PR TITLE
Bugfixes: Confuse Berries, Pinch + Contrary

### DIFF
--- a/bin/db/items/berry_effects.txt
+++ b/bin/db/items/berry_effects.txt
@@ -8,11 +8,11 @@
 7 1--1#Persim
 8 1-0#Lum
 9 3-30#pinch Sitrus
-10 #confusing stupid berry
-11 #confusing stupid berry
-12 #confusing stupid berry
-13 #confusing stupid berry
-14 #confusing stupid berry
+10 6#ConfuseBerry
+11 6#ConfuseBerry
+12 6#ConfuseBerry
+13 6#ConfuseBerry
+14 6#ConfuseBerry
 35 4-9
 36 4-10
 37 4-12 

--- a/bin/db/items/berry_messages.txt
+++ b/bin/db/items/berry_messages.txt
@@ -1,12 +1,12 @@
 ﻿0 %s ate its %i!
-1 %s snapped out of its confusion!|%s's status cleared!|%s is not paralyzed anymore!|%s woke up!|%s thawed out!|%s healed from its burnt!|%s is cured from its poison!
+1 %s snapped out of its confusion!|%s's status cleared!|%s is not paralyzed anymore!|%s woke up!|%s thawed out!|%s healed from its burn!|%s is cured from its poison!
 2 %s's %m's PPs are restored!|%s's PPs are restored!
 3 %s restored some HP!
 4 %s's %i weakened %m's power!
 5 %s's %i weakened %m's power!
 6 %s restored some HP!
-7 The %i raised %s's %st!
-9 The %i sharply raised %s's %st!
+7 The %i raised %s's %st!|The %i lowered %s's %st!
+9 The %i sharply raised %s's %st!|The %i sharply lowered %s's %st!
 10 %s is focusing on the target!
 11 %s is already preparing its next move!
 12 %f is hit with recoil

--- a/src/BattleManager/proxydatacontainer.h
+++ b/src/BattleManager/proxydatacontainer.h
@@ -841,7 +841,7 @@ public:
         SweetHeart,
         PrismScale,
         Eviolite,
-        PumiceStone,
+        FloatStone,
         RockyHelmet,
         AirBalloon,
         RedCard,

--- a/src/Server/berries.cpp
+++ b/src/Server/berries.cpp
@@ -148,8 +148,13 @@ struct BMPinchHP : public BMPinch
     }
 
     static void tp(int p, int s, BS &b) {
-        if (!testpinch(p, s, b,2))
+        if (!b.canHeal(s))
             return;
+
+
+        if (!testpinch(p, s, b, 2))
+            return;
+
 
         b.sendBerryMessage(3,s,0);
         int arg = poke(b,p)["ItemArg"].toInt();
@@ -217,11 +222,9 @@ struct BMSuperHP : public BM
         if (!b.attacking()) {
             return;
         }
-        if (b.koed(s))
+        if (!b.canHeal(s))
             return;
         if (fturn(b,t).typeMod <= 4)
-            return;
-        if (b.poke(s).isFull())
             return;
         b.eatBerry(s);
         b.sendBerryMessage(6,s,0);
@@ -258,7 +261,11 @@ struct BMPinchStat : public BMPinch
         int arg = poke(b,p)["ItemArg"].toInt();
 
         if (b.isOut(s)) {
-            b.sendBerryMessage(7,s,0,s, berry, arg);
+            if (b.hasWorkingAbility(s, Ability::Contrary)) {
+                b.sendBerryMessage(7,s,1,s, berry, arg);
+            } else {
+                b.sendBerryMessage(7,s,0,s, berry, arg);
+            }
             b.inflictStatMod(s, arg, 1, s, false);
         }
     }
@@ -344,8 +351,12 @@ struct BMStarf : public BMPinch
             return;
 
         int stat = stats[b.randint(stats.size())];
+        if (b.hasWorkingAbility(s, Ability::Contrary)) {
+            b.sendBerryMessage(9,s,1,s, berry, stat);
+        } else {
+            b.sendBerryMessage(9,s,0,s, berry, stat);
+        }
         b.inflictStatMod(s, stat, 2, s, false);
-        b.sendBerryMessage(9,s,0,s,berry,stat);
     }
 };
 
@@ -419,6 +430,41 @@ struct BMBerryRecoil : public BM
     }
 };
 
+struct BMConfuseBerry : public BMPinch
+{
+    BMConfuseBerry() {
+        functions["AfterHPChange"] = &ahpc;
+        functions["TestPinch"] = &tp;
+    }
+
+    static void ahpc(int p, int s, BS &b) {
+        /* Those berries don't activate immediately when attacked by offensive moves,
+           but only after side effects applied. At that time, the battle thread will call
+           the effect "TestPinch"
+        */
+        if (b.attacked() == s && tmove(b,b.attacker()).power > 0)
+            return;
+        tp(p, s, b);
+    }
+
+    static void tp (int p, int s, BS &b) {
+        if (!b.isOut(s))
+            return;
+
+        if (!testpinch(p, s, b, 4))
+            return;
+
+        if (!b.canHeal(s))
+            return;
+
+        b.eatBerry(s);
+        b.sendBerryMessage(6,s,0);
+        b.healLife(s, b.poke(s).totalLifePoints()/8);
+        //Fixme: Nature checking for Trick, Switcheroo, Covet, Thief, Bug Bite, Fling, etc.
+        b.inflictConfused(s,s);
+    }
+};
+
 #define REGISTER_BERRY(num, name) mechanics[num+8000] = BM##name(); names[num+8000] = #name; nums[#name] = num+8000;
 
 void ItemEffect::initBerries()
@@ -435,4 +481,5 @@ void ItemEffect::initBerries()
     REGISTER_BERRY(10, BerryLock);
     REGISTER_BERRY(11, Custap);
     REGISTER_BERRY(12, BerryRecoil);
+    REGISTER_BERRY(13, ConfuseBerry);
 }


### PR DESCRIPTION
-Fixes typo in burn heal berries
-Includes an item I forgot to localize
-Adds function for Figy Berry, etc.
-Corrects message for Pinch Berries with Contrary
