### PR TITLE
Bugfix: Incorrect messages for Pursuit/Focus Punch

### DIFF
--- a/src/Server/battle.cpp
+++ b/src/Server/battle.cpp
@@ -1044,7 +1044,8 @@ void BattleSituation::sendBack(int player, bool silent)
         QList<int> opps = revs(player);
         bool notified = false;
         foreach(int opp, opps) {
-            if (tmove(opp).attack == Move::Pursuit && !turnMem(opp).contains(TurnMemory::HasMoved) && !turnMemory(player).contains("RedCardUser")) {
+            //Pursuit does not deal additional effects to a teammate switching
+            if (tmove(opp).attack == Move::Pursuit && !turnMem(opp).contains(TurnMemory::HasMoved) && !turnMemory(player).contains("RedCardUser") && !arePartners(opp, player)) {
                 if (!notified) {
                     notified = true;
                     sendMoveMessage(171, 0, player);

--- a/src/Server/moves.cpp
+++ b/src/Server/moves.cpp
@@ -924,7 +924,9 @@ struct MMFocusPunch : public MM
     }
 
     static void os(int s, int, BS &b) {
-        if (b.poke(s).status() != Pokemon::Frozen && b.poke(s).status() != Pokemon::Paralysed)
+        //Pokemon who are Frozen, Asleep and Paralyzed will display the message showing it "is tightening its focus"
+        //DAF and Status effects will handle the second message correctly. Commenting out code just in case it changes for Gen 6
+        //if (b.poke(s).status() != Pokemon::Frozen && b.poke(s).status() != Pokemon::Paralysed && b.poke(s).status() != Pokemon::Asleep)
             b.sendMoveMessage(47,1,s,Pokemon::Fighting);
     }
 };
@@ -4523,6 +4525,7 @@ struct MMSleepTalk : public MM
     struct FM : public QSet<int> {
         FM() {
             //Sleep Talk prevents all 2-Turn moves
+            //Fixme: Gen 4 and below Mimic should have the move replaced, not Sleep Talk
             (*this) << NoMove << Bide << Bounce << Chatter << Copycat << Dig << Dive << Fly
                               << FocusPunch << MeFirst << Metronome << MirrorMove << ShadowForce
                               << SkullBash << SkyAttack << SleepTalk << SolarBeam << Struggle << RazorWind


### PR DESCRIPTION
Messages correctly follow in-game mechanics, commented out old code in case something changes in Gen 6 (which might be likely)

Pursuit also not supposed to negatively impact an ally switch (Found while testing for Pursuit + Sleep mechanics)

Also added note about mechanic confirmation with Sleep Talk/Mimic by Derwin.
