### PR TITLE
Fix sys.exists not working anymore

### DIFF
--- a/src/Server/scriptengine.cpp
+++ b/src/Server/scriptengine.cpp
@@ -223,7 +223,8 @@ ScriptEngine::ScriptEngine(Server *s) {
     sys.setProperty( "append" , apf);
     sys.setProperty( "appendToFile" , apf);
 
-    sys.setProperty( "exists" , myengine.newFunction(exists));
+    sys.setProperty( "fileExists" , myengine.newFunction(exists));
+    sys.setProperty( "fexists" , myengine.newFunction(exists));
 
     sys.setProperty( "exec" , myengine.newFunction(exec));
 


### PR DESCRIPTION
Didn't know there was already a function called sys.exists. I don't know if anyone even uses it, but to be safe the new sys.exists is now named sys.fexists.
