### PR TITLE
Remove channel limit

### DIFF
--- a/src/Server/player.cpp
+++ b/src/Server/player.cpp
@@ -370,8 +370,8 @@ void Player::joinRequested(const QString &name)
         return;
     }
     /* Too many channels */
-    if (auth() == 0 && channels.size() >= 12) {
-        sendMessage("You can't join more than 12 channels");
+    if (auth() == 0 && channels.size() >= 20) {
+        sendMessage("You can't join more than 20 channels");
         return;
     }
 


### PR DESCRIPTION
I don't see the point of it since /cjoin gets past it anyways. I know not all servers have it but meh, it just servers to kinda annoy people with autojoins :(
