### PR TITLE
Enable Seconds in PM Timestamp

### DIFF
--- a/src/Teambuilder/client.cpp
+++ b/src/Teambuilder/client.cpp
@@ -846,6 +846,11 @@ void Client::showTimeStamps2(bool b)
     globals.setValue("PMs/ShowTimestamps", b);
 }
 
+void Client::showSeconds(bool b)
+{
+    globals.setValue("PMs/ShowSeconds", b);
+}
+
 void Client::toggleIncomingPM(bool b)
 {
     globals.setValue("PMs/RejectIncoming", b);
@@ -1345,10 +1350,15 @@ QMenuBar * Client::createMenuBar(MainEngine *w)
     connect(save_logs, SIGNAL(triggered(bool)), SLOT(togglePMLogs(bool)));
     save_logs->setChecked(globals.value("PMs/Logged").toBool());
 
-    QAction * show_ts2 = pmMenu->addAction(tr("Enable timestamps in &PMs"));
+    QAction * show_ts2 = pmMenu->addAction(tr("Enable timestamps in PMs"));
     show_ts2->setCheckable(true);
     connect(show_ts2, SIGNAL(triggered(bool)), SLOT(showTimeStamps2(bool)));
     show_ts2->setChecked(globals.value("PMs/ShowTimestamps").toBool());
+
+    QAction * show_sec = pmMenu->addAction(tr("Enable seconds in PMs"));
+    show_sec->setCheckable(true);
+    connect(show_sec, SIGNAL(triggered(bool)), SLOT(showSeconds(bool)));
+    show_sec->setChecked(globals.value("PMs/ShowSeconds").toBool());
 
     QAction * pm_reject = pmMenu->addAction(tr("Reject incoming PMs"));
     pm_reject->setCheckable(true);

--- a/src/Teambuilder/client.h
+++ b/src/Teambuilder/client.h
@@ -290,6 +290,7 @@ public slots:
     bool ignoringGlobalMessage(const QString &channelName);
     void showTimeStamps(bool);
     void showTimeStamps2(bool);
+    void showSeconds(bool);
     void toggleIncomingPM(bool);
     void togglePMTabs(bool);
     void togglePMNotifications(bool);

--- a/src/Teambuilder/mainwindow.cpp
+++ b/src/Teambuilder/mainwindow.cpp
@@ -85,6 +85,7 @@ MainEngine::MainEngine(bool updated) : displayer(0), freespot(0)
     setDefaultValue(s, "PlayerEvents/ShowChannel", false);
     setDefaultValue(s, "PlayerEvents/ShowTeam", false);
     setDefaultValue(s, "PMs/ShowTimestamps", true);
+    setDefaultValue(s, "PMs/ShowSeconds", false);
     //setDefaultValue(s, "PMs/Flash", true); //deleted that feature
     setDefaultValue(s, "PMs/RejectIncoming", false);
     setDefaultValue(s, "PMs/Tabbed", true);

--- a/src/Teambuilder/pmsystem.cpp
+++ b/src/Teambuilder/pmsystem.cpp
@@ -249,10 +249,16 @@ void PMStruct::printLine(const QString &line, bool self)
 
     QSettings s;
     bool tt = s.value("PMs/ShowTimestamps").toBool();
+    bool ss = s.value("PMs/ShowSeconds").toBool();
     QString timeStr = "";
 
-    if (tt)
-        timeStr += "(" + QTime::currentTime().toString("hh:mm") + ") ";
+    if (tt) {
+        if (ss) {
+            timeStr += "(" + QTime::currentTime().toString("hh:mm:ss") + ") ";
+        } else {
+            timeStr += "(" + QTime::currentTime().toString("hh:mm") + ") ";
+        }
+    }
 
     QString eline = escapeHtml(line);
 
@@ -268,10 +274,16 @@ void PMStruct::printHtml(const QString &htmlCode, bool timestamps)
 {
     QSettings s;
     bool tt = s.value("PMs/ShowTimestamps").toBool();
+    bool ss = s.value("PMs/ShowSeconds").toBool();
     QString timeStr = "";
 
-    if (tt && timestamps)
-        timeStr += "(" + QTime::currentTime().toString("hh:mm") + ") ";
+    if (tt && timestamps) {
+        if (ss) {
+            timeStr += "(" + QTime::currentTime().toString("hh:mm:ss") + ") ";
+        } else {
+            timeStr += "(" + QTime::currentTime().toString("hh:mm") + ") ";
+        }
+    }
 
     m_mainwindow->insertHtml(timeStr + removeTrollCharacters(htmlCode) + "<br />");
     log->pushHtml(timeStr + removeTrollCharacters(htmlCode) + "<br />");


### PR DESCRIPTION
Tested and confirmed working. I think the code is as clean as it can get.

Requested feature by a few MAs to determine deadtalks more accurately.
