### PR TITLE
Fixed min damage bug, 5th gen can now have 0 damage

### DIFF
--- a/src/Server/battle.cpp
+++ b/src/Server/battle.cpp
@@ -2894,7 +2894,7 @@ void BattleSituation::inflictDamage(int player, int damage, int source, bool str
         callieffects(player, source, "BeforeTakingDamage");
     }
 
-    if (damage == 0) {
+    if (damage == 0 && gen() <= 4) {
         damage = 1;
     }
 


### PR DESCRIPTION
http://pokemon-online.eu/forums/showthread.php?21272-Minimum-damage-bug&p=298890&viewfull=1#post298890

Not sure what the behavior is for past gens, so that was left as is.
