### PR TITLE
Update moves.txt

### DIFF
--- a/bin/trans/de/db/moves/moves.txt
+++ b/bin/trans/de/db/moves/moves.txt
@@ -428,7 +428,7 @@
 427 Psychoklinge
 428 Zen-Kopfstoß
 429 Spiegelsalve
-430 Blitzkanone
+430 Lichtkanone
 431 Kraxler
 432 Auflockern
 433 Bizarroraum


### PR DESCRIPTION
Fixes a problem with the moves Zap Cannon and Flash Cannon in the German version of PO. They had the same translation, so it was very buggy. 
http://pokemon-online.eu/forums/showthread.php?19315-Flash-Canon-in-German-version
(Fixes this bug, so the thread can marked with fixed of next update).
