### PR TITLE
Ooze/Magic Guard Fix

### DIFF
--- a/src/Server/battle.cpp
+++ b/src/Server/battle.cpp
@@ -2073,6 +2073,9 @@ void BattleSituation::inflictRecoil(int source, int target)
         }
 
         if (hasWorkingAbility(target, Ability::LiquidOoze)) {
+            if (hasWorkingAbility(source,Ability::MagicGuard))
+                return;
+
             if (gen().num < 5 && tmove(source).attack == Move::DreamEater) {
                 healLife(source, damage);
             } else {


### PR DESCRIPTION
There was something earlier in the code that checked for recoil off a move, but not draining moves.
