### PR TITLE
Made sys.abilityNum not case sensitive

### DIFF
--- a/src/ClientScripting/scriptengine.cpp
+++ b/src/ClientScripting/scriptengine.cpp
@@ -656,7 +656,7 @@ QScriptValue ScriptEngine::ability(int num)
 
 QScriptValue ScriptEngine::abilityNum(const QString &ability)
 {
-    return AbilityInfo::Number(ability);
+    return AbilityInfo::Number(convertToSerebiiName(ability));
 }
 
 QScriptValue ScriptEngine::genderNum(QString genderName)


### PR DESCRIPTION
Seems silly that everything else works when this doesn't, and I might need it not case sensitive if I'm going to make /ability. If I'm not supposed to change this, just go ahead and close this request.
