### PR TITLE
More gen 6 changes

### DIFF
--- a/bin/db/moves/6G/special_effect.txt
+++ b/bin/db/moves/6G/special_effect.txt
@@ -285,6 +285,7 @@
 559 194#Cross Thunder
 560 #
 562 199#Crafty shield
+566 126#Flying Press
 567 157-11#Forest's Curse
 569 104-6#Geomancy
 571 10#Infestation

--- a/src/Server/abilities.cpp
+++ b/src/Server/abilities.cpp
@@ -533,15 +533,28 @@ struct AMFrisk : public AM {
     }
 
     static void us(int s, int , BS &b) {
-        int t = b.randomOpponent(s);
+        if (b.gen() < 6) {
+            int t = b.randomOpponent(s);
 
-        if (t == -1)
-            return;
+            if (t == -1)
+                return;
 
-        int it = b.poke(t).item();
+            int it = b.poke(t).item();
 
-        if (it != 0) {
-            b.sendAbMessage(23,0,s,t,0,it);
+            if (it != 0) {
+                b.sendAbMessage(23,0,s,t,0,it);
+            }
+        } else {
+            foreach(int t, b.revs(s)) {
+                if (!b.areAdjacent(s, t)) {
+                    continue;
+                }
+                int it = b.poke(t).item();
+
+                if (it != 0) {
+                    b.sendAbMessage(23,0,s,t,0,it);
+                }
+            }
         }
     }
 };

--- a/src/Server/battle.cpp
+++ b/src/Server/battle.cpp
@@ -1139,6 +1139,8 @@ bool BattleSituation::testAccuracy(int player, int target, bool silent)
                                                                                                                             || move == Move::Transform))) {
         return true;
     }
+
+    //Toxic always hits if used by poison type in gen 6
     if (move == Move::Toxic && gen() > 5 && hasType(player, Type::Poison)) {
         return true;
     }
@@ -3724,10 +3726,10 @@ PokeFraction BattleSituation::getStatBoost(int player, int stat)
     int attacked = this->attacked();
 
     if (attacker != -1 && attacked != -1) {
-        //Unaware / Sacred sword
+        //Unaware / Sacred sword / Keeneye ignores evasion in gen 6
         if (attacker != player && attacked == player) {
             if ((hasWorkingAbility(attacker, Ability::Unaware) || tmove(attacker).attack == Move::ChipAway || tmove(attacker).attack == Move::SacredSword)
-                    && (stat == SpDefense || stat == Defense || stat == Evasion)) {
+                    && (stat == SpDefense || stat == Defense || stat == Evasion) || gen() > 5 && stat == Evasion && hasWorkingAbility(attacker, Ability::KeenEye)) {
                 boost = 0;
             }
         } else if (attacker == player && attacked != player && hasWorkingAbility(attacked, Ability::Unaware) &&


### PR DESCRIPTION
Frisk gets item of multiple pokemon in multi-battles (doesn't tell you which Pokémon is holding it though...)
SecretPower changes dependent on terrain
Phantom Force/Flying Press has the same effect as stomp/steamroller on minimize. I was wrong about dragon rush not hitting. (Phantom Force isn't fully done since I'm not sure how to do the second turn... :( )
Keen eye ignores evasion boosts
Oblivious ignores taunt too

I tried doing Phantom's Force second turn, but when testing it didn't work! So I just removed it :x
