### PR TITLE
Changing format of PM Timestamp to make logs less confusing

### DIFF
--- a/src/Teambuilder/pmsystem.cpp
+++ b/src/Teambuilder/pmsystem.cpp
@@ -255,9 +255,9 @@ void PMStruct::printLine(const QString &line, bool self)
 
     if (tt) {
         if (ss) {
-            timeStr += "(" + QTime::currentTime().toString("hh:mm:ss") + ") ";
+            timeStr += "[" + QTime::currentTime().toString("hh:mm:ss") + "] ";
         } else {
-            timeStr += "(" + QTime::currentTime().toString("hh:mm") + ") ";
+            timeStr += "[" + QTime::currentTime().toString("hh:mm") + "] ";
         }
     }
 
@@ -280,9 +280,9 @@ void PMStruct::printHtml(const QString &htmlCode, bool timestamps)
 
     if (tt && timestamps) {
         if (ss) {
-            timeStr += "(" + QTime::currentTime().toString("hh:mm:ss") + ") ";
+            timeStr += "[" + QTime::currentTime().toString("hh:mm:ss") + "] ";
         } else {
-            timeStr += "(" + QTime::currentTime().toString("hh:mm") + ") ";
+            timeStr += "[" + QTime::currentTime().toString("hh:mm") + "] ";
         }
     }
 


### PR DESCRIPTION
(13:02:38) Fuzzy: This is a PM!
(12:56:03) Fuzzy: This is a chat!
will turn into
[13:02:38] Fuzzy: This is a PM!
(12:56:03) Fuzzy: This is a chat!
Making it much easier to tell when someone with PM seconds posts a log in Indigo/VR.
