### PR TITLE
Fix unclear ban messages

### DIFF
--- a/src/Server/tier.cpp
+++ b/src/Server/tier.cpp
@@ -266,25 +266,26 @@ QString Tier::bannedReason(const PokeBattle &p) const {
         if(bannedMoves.size() > 0) {
             for(int i = 0; i < 4; i++) {
                 if(bannedMoves.contains(p.move(i).num())) {
-                    errorList += QString("%1, ").arg(MoveInfo::Name(p.move(i).num()));
+                    errorList += QString("Move %1 is banned, ").arg(MoveInfo::Name(p.move(i).num()));
                 }
             }
         }
         if(bannedItems.contains(p.item())) {
-            errorList += QString("Item %1, ").arg(ItemInfo::Name(p.item()));
+            errorList += QString("Item %1 is banned, ").arg(ItemInfo::Name(p.item()));
         }
+    } else {
         if(bannedPokes.size() > 0 && !bannedPokes.contains(PokemonInfo::NonAestheticForme(p.num()))) {
             errorList += QString("Pokemon %1 is banned, ").arg(PokemonInfo::Name(p.num()));
         }
         if(bannedMoves.size() > 0) {
             for(int i = 0; i < 4; i++) {
                 if(p.move(i).num() != 0 && !bannedMoves.contains(p.move(i).num())) {
-                    errorList += QString("%1, ").arg(MoveInfo::Name(p.move(i).num()));
+                    errorList += QString("Move %1 is banned, ").arg(MoveInfo::Name(p.move(i).num()));
                 }
             }
         }
         if(bannedItems.size() > 0 && p.item() != 0 && !bannedItems.contains(p.item())) {
-            errorList += QString("%1, ").arg(ItemInfo::Name(p.item()));
+            errorList += QString("Item %1 is banned, ").arg(ItemInfo::Name(p.item()));
         }
     }
     if(errorList.length() >= 2) {


### PR DESCRIPTION
Old Messages
(18:15:09) The Pokemon 'Darkrai' is banned on tier 'XY OU' for the following reasons: Pokemon Darkrai is banned, Dark Pulse, Life Orb. 
Darkrai is the banned thing here, the message makes it kinda clear, but the move/item are unneeeded
(18:15:40) The Pokemon 'Garchomp' is banned on tier 'XY OU' for the following reasons: Double Team, Pokemon Garchomp is banned, Life Orb. 
Here Double Team is banned, but the message is confusing and might make people think Garchomp itself is banned
(18:16:08) The Pokemon 'Garchomp' is banned on tier 'XY OU' for the following reasons: Item Soul Dew, Pokemon Garchomp is banned, Dual Chop.
Same as above, but Soul Dew is banned.

New Messages
(18:17:58) The Pokemon 'Darkrai' is banned on tier 'XY OU' for the following reasons: Pokemon Darkrai is banned.
(18:18:28) The Pokemon 'Garchomp' is banned on tier 'XY OU' for the following reasons: Move Double Team is banned.
(18:19:05) The Pokemon 'Garchomp' is banned on tier 'XY OU' for the following reasons: Item Soul Dew is banned.

Much clearer on what is actually banned now >:O
