### PR TITLE
Fix AntiDoS bans

### DIFF
--- a/src/Server/security.cpp
+++ b/src/Server/security.cpp
@@ -319,6 +319,10 @@ void SecurityManager::ban(const QString &name, int time) {
 
 void SecurityManager::banIP(const QString &ip)
 {
+    if (bannedIPs.contains(ip)) {
+        return;
+    }
+
     bannedIPs.insert(ip, 0);
     create(ip,QDateTime::currentDateTime().toString(Qt::ISODate),ip,true);
 }

--- a/src/Server/server.cpp
+++ b/src/Server/server.cpp
@@ -845,10 +845,10 @@ void Server::tempBan(int dest, int src, int time)
 
 void Server::dosKick(int id) {
     if (playerExist(id) && overactiveShow) {
-        ip = player(id)->ip();
+        QString ip = player(id)->ip();
         if (!SecurityManager::bannedIP(ip)) {
             if (playerLoggedIn(id)) {
-                broadCast(tr("Player %1 (IP %2) is being overactive.").arg(name(id), ip)), dosChannel());
+                broadCast(tr("Player %1 (IP %2) is being overactive.").arg(name(id), ip), dosChannel());
             } else {
                 broadCast(tr("IP %1 is being overactive.").arg(ip), dosChannel());
             }
@@ -862,7 +862,7 @@ void Server::dosBan(const QString &ip) {
         if (overactiveShow) {
             broadCast(tr("IP %1 is being overactive, banned.").arg(ip), dosChannel());
         }
-        SecurityManager::ban(ip);
+        SecurityManager::banIP(ip);
     }
 }
 


### PR DESCRIPTION
Server now uses SecurityManager::banIP instead of ::ban. Should fix a lot of the problems people have been encountering.
