### PR TITLE
Fix solid rock/filter/expert belt

### DIFF
--- a/src/Server/battle.cpp
+++ b/src/Server/battle.cpp
@@ -3073,12 +3073,12 @@ int BattleSituation::calculateDamage(int p, int t)
 
         /* Mod 3 */
         // FILTER / SOLID ROCK
-        if (typemod > 0 && (hasWorkingAbility(t,Ability::Filter) || hasWorkingAbility(t,Ability::SolidRock))) {
+        if (turnMem(p).typeMod > 0 && (hasWorkingAbility(t,Ability::Filter) || hasWorkingAbility(t,Ability::SolidRock))) {
             damage = damage * 3 / 4;
         }
 
         /* Expert belt */
-        damage = damage * ((typemod > 0 && hasWorkingItem(p, Item::ExpertBelt))? 6 : 5)/5;
+        damage = damage * ((turnMem(p).typeMod > 0 && hasWorkingItem(p, Item::ExpertBelt))? 6 : 5)/5;
 
         move.remove("Mod3Berry");
 


### PR DESCRIPTION
The two while loops before these checks, made sure that typeMod is always equal to 0. So I used a similar method to what berries use to make sure it gets the original typeMod.
