### PR TITLE
Sticky Web+Defiant/competitive/mist/flower veil

### DIFF
--- a/src/Server/moves.cpp
+++ b/src/Server/moves.cpp
@@ -6892,10 +6892,11 @@ struct MMStickyWeb : public MM
     }
 
     static void usi(int source, int s, BS &b) {
+        int t = b.opponent(b.player(s));
         if (!b.koed(s) && team(b,source).value("StickyWeb").toBool() == true && !b.hasWorkingAbility(s, Ability::ClearBody) && !b.isFlying(s))
         {
             b.sendMoveMessage(210,1,s,Pokemon::Bug);
-            b.inflictStatMod(s, Speed, -1, s);
+            b.inflictStatMod(s, Speed, -1, t);
         }
     }
 };


### PR DESCRIPTION
Defiant/Competitive should activate on Sticky Web
Also me and Wriggle tested Mist/Flower Veil and found that it's immune to sticky web too.
This change just makes the loss of speed come from the enemy instead of the player :x
