### PR TITLE
Close internal battle server on shutdown

### DIFF
--- a/src/Server/battlecommunicator.cpp
+++ b/src/Server/battlecommunicator.cpp
@@ -142,6 +142,13 @@ FullBattleConfiguration *BattleCommunicator::battle(int battleid)
     return mybattles.value(battleid);
 }
 
+void BattleCommunicator::killServer()
+{
+    if (battleServer->state() == QProcess::Running) {
+        battleServer->kill();
+    }
+}
+
 bool BattleCommunicator::startServer()
 {
     if (battleServer->state() == QProcess::Starting || battleServer->state() == QProcess::Running) {

--- a/src/Server/battlecommunicator.h
+++ b/src/Server/battlecommunicator.h
@@ -47,6 +47,7 @@ signals:
     void battleFinished(int,int,int,int);
     void sendBattleInfos(int,int,int,const TeamBattle&,const BattleConfiguration&,const QString&);
 public slots:
+    void killServer();
     bool startServer();
     void connectToBattleServer();
     void battleConnected();

--- a/src/Server/server.cpp
+++ b/src/Server/server.cpp
@@ -1953,6 +1953,7 @@ void Server::atServerShutDown() {
 
     myengine->serverShutDown();
 
+    battles->killServer();
 #ifdef _WIN32
     ::exit(0);
 #endif


### PR DESCRIPTION
It doesn't close the internal battle server when it crashes, but that isn't ideal anyway! (and there's not much to do about :( )
