### PR TITLE
ClientScripting fixes

### DIFF
--- a/src/ClientScripting/scriptengine.cpp
+++ b/src/ClientScripting/scriptengine.cpp
@@ -94,11 +94,10 @@ QScriptValue ScriptEngine::tint(QScriptContext *ctxt, QScriptEngine *engine)
 
 ScriptEngine::ScriptEngine(ClientInterface *c) {
     myclient = c;
+    myengine.setParent(this);
     armScriptEngine(&myengine);
 
     connect(&manager, SIGNAL(finished(QNetworkReply*)), SLOT(webCall_replyFinished(QNetworkReply*)));
-    changeScript(ScriptUtils::loadScripts());
-    changeBattleScript(ScriptUtils::loadScripts(ScriptUtils::BattleScripts));
 
     QTimer *step_timer = new QTimer(this);
     step_timer->setSingleShot(false);
@@ -108,8 +107,15 @@ ScriptEngine::ScriptEngine(ClientInterface *c) {
     QSettings s;
     safeScripts = s.value("ScriptWindow/safeScripts", true).toBool();
     warnings = s.value("ScriptWindow/warn", true).toBool();
-
     datalocation = appDataPath("Scripts/", true) + "/data.ini";
+
+    changeScript(ScriptUtils::loadScripts());
+    changeBattleScript(ScriptUtils::loadScripts(ScriptUtils::BattleScripts));
+}
+
+ClientInterface* ScriptEngine::client()
+{
+    return myclient;
 }
 
 void ScriptEngine::armScriptEngine(QScriptEngine *engine)
@@ -240,8 +246,7 @@ QScriptValue ScriptEngine::channelNames(QScriptContext *context, QScriptEngine *
 {
     (void) context;
 
-    ClientInterface *c = dynamic_cast<ClientInterface*>(engine->globalObject().property("client").toQObject());
-
+    ClientInterface *c = qobject_cast<ScriptEngine*>(engine->parent())->client();
     return qScriptValueFromValue(engine, c->getChannelNames());
 }
 

--- a/src/ClientScripting/scriptengine.h
+++ b/src/ClientScripting/scriptengine.h
@@ -231,6 +231,7 @@ private:
     void printLine(const QString &s);
     void armScriptEngine(QScriptEngine *engine);
     void armScripts(QScriptEngine *engine, const QString &scripts, bool trigger=false);
+    ClientInterface* client();
 
     void warn(const QString &function, const QString &message);
 

--- a/src/ClientScripting/scriptwindow.cpp
+++ b/src/ClientScripting/scriptwindow.cpp
@@ -51,33 +51,17 @@ ScriptWindow::~ScriptWindow()
 void ScriptWindow::safeScriptsChanged(int newStatus)
 {
     QSettings s;
+    bool checked = newStatus == Qt::Checked;
 
-    s.beginGroup("ScriptWindow");
-
-    if (newStatus == Qt::Checked) {
-        s.setValue("safeScripts", true);
-        emit safeScriptsChanged(true);
-    } else {
-        s.setValue("safeScripts", false);
-        emit safeScriptsChanged(false);
-    }
-
-    s.endGroup();
+    s.setValue("ScriptWindow/safeScripts", checked);
+    emit safeScriptsChanged(checked);
 }
 
 void ScriptWindow::warningsChanged(int newStatus)
 {
     QSettings s;
+    bool checked = newStatus == Qt::Checked;
 
-    s.beginGroup("ScriptWindow");
-
-    if (newStatus == Qt::Checked) {
-        s.setValue("warn", true);
-        emit warningsChanged(true);
-    } else {
-        s.setValue("warn", false);
-        emit warningsChanged(false);
-    }
-
-    s.endGroup();
+    s.setValue("ScriptWindow/warn", checked);
+    emit warningsChanged(checked);
 }


### PR DESCRIPTION
This fixes problems with safe scripts being set _after_ the script is evaluated (so code that isn't in clientStartUp which requests file access won't work).

``` javascript
sys.getFileContent("error"); // -> undefined/error/warning (quite random), fixed
({
  clientStartUp: function () {
    sys.getFileContent("works"); // this always worked
  }
})
```
