### PR TITLE
SESSION fixes/changes

### DIFF
--- a/src/Server/scriptengine.h
+++ b/src/Server/scriptengine.h
@@ -14,10 +14,10 @@
 
 #include "../PokemonInfo/geninfo.h"
 #include "../Utilities/functions.h"
-#include "sessiondatafactory.h"
 
 class Server;
 class ChallengeInfo;
+class SessionDataFactory;
 
 class ScriptEngine : public QObject
 {
@@ -496,6 +496,9 @@ public:
             return proc->pid();
         #endif // Q_WS_WIN
     }
+    Server* getServer();
+    QScriptEngine* getEngine();
+    void printLine(const QString &s);
 signals:
     void stdoutReceived(quint64 pid, const QString &procStdout);
     void stderrReceived(quint64 pid, const QString &procStderr);
@@ -566,7 +569,6 @@ private:
     QString sync_data;
 
     void evaluate(const QScriptValue &expr);
-    void printLine(const QString &s);
 
     bool testPlayer(const QString &function, int id);
     bool testTeamCount(const QString &function, int id, int team);

--- a/src/Server/server.h
+++ b/src/Server/server.h
@@ -30,6 +30,7 @@ class Server: public QObject, public ServerInterface
     Q_OBJECT
 
     friend class ScriptEngine;
+    friend class SessionDataFactory;
     friend class ServerWidget;
     friend class ConsoleReader;
     friend class RegistryCommunicator;

--- a/src/Server/sessiondatafactory.h
+++ b/src/Server/sessiondatafactory.h
@@ -1,23 +1,26 @@
 #ifndef SESSIONDATAFACTORY_H
 #define SESSIONDATAFACTORY_H
 
-#include <QObject>
-#include <QtScript>
-#include <QString>
+#include "scriptengine.h"
+#include "server.h"
 
 class SessionDataFactory : public QObject
 {
-Q_OBJECT
+    Q_OBJECT
+    Q_ENUMS(RefillType)
 public:
-    explicit SessionDataFactory(QScriptEngine *engineLink);
-    void disableAll();
+    SessionDataFactory(ScriptEngine *engine);
+    Q_INVOKABLE void disableAll();
     void handleUserLogIn(int user_id);
     void handleUserLogOut(int user_id);
     void handleChannelCreate(int channel_id);
     void handleChannelDestroy(int channel_id);
-    void handleInitialState();
-    bool isRefillNeeded();
-    void refillDone(); // called by external code to signal that refilling is done.
+
+    enum RefillType {
+        RefillAll,
+        RefillUsers,
+        RefillChannels
+    };
 
     Q_INVOKABLE void registerUserFactory(QScriptValue factoryFunction);
     Q_INVOKABLE void registerChannelFactory(QScriptValue factoryFunction);
@@ -25,23 +28,25 @@ public:
     Q_INVOKABLE QScriptValue users(int id);
     Q_INVOKABLE QScriptValue channels(int id);
     Q_INVOKABLE QScriptValue global();
+    Q_INVOKABLE bool hasUser(int id);
+    Q_INVOKABLE bool hasChannel(int id);
     Q_INVOKABLE void identifyScriptAs(QString scriptId);
-
+    Q_INVOKABLE void clearAll();
+    Q_INVOKABLE void refill(RefillType type = RefillAll);
+    Q_INVOKABLE QString dump();
 private:
-    QScriptEngine *engine;
+    ScriptEngine *engine;
+    QScriptEngine *scriptEngine;
     QScriptValue userFactoryFunction;
     QScriptValue channelFactoryFunction;
     QHash<int, QScriptValue> userFactoryStorage;
     QHash<int, QScriptValue> channelFactoryStorage;
     bool userFactoryEnabled;
     bool channelFactoryEnabled;
-    bool initialStateHandled;
+    bool globalFactoryEnabled;
     QString currentScriptId;
-    void clearAll();
     QScriptValue globalFactoryFunction;
     QScriptValue globalFactoryStorage;
-    bool globalFactoryEnabled;
-    bool refillNeeded;
     void checkError();
 };
 

--- a/tests/data/server/scripts.js
+++ b/tests/data/server/scripts.js
@@ -1,0 +1,69 @@
+if (typeof load === "undefined") {
+    load = 0;
+}
+
+if (typeof tests === "undefined") {
+    tests = {};
+}
+
+load += 1;
+
+if (load === 1 || load === 2) {
+    SESSION.identifyScriptAs("SESSION.1");
+} else {
+    SESSION.identifyScriptAs("SESSION.2");
+}
+
+SESSION.registerUserFactory(function () { this.messageSent = false; });
+SESSION.registerChannelFactory(function () {});
+SESSION.registerGlobalFactory(function () { this.messageSent = false; });
+
+function fail(state) { sys.sendAll("fail", 0); print("state: " + state); }
+function success() { sys.sendAll("accept", 0); }
+function reloadScripts() { sys.changeScript(sys.getFileContent("scripts.js")); }
+
+tests.session = {
+    run: function (src, chan) {
+        tests.session.state[1](src, chan);
+    },
+    state: {
+        '1': function (src, chan) {
+            print("TestSESSION: State #1");
+            if (SESSION.hasUser(src) && SESSION.hasChannel(chan)) {
+                SESSION.users(src).messageSent = true;
+                SESSION.global().messageSent = true;
+                tests.session.state[2](src, chan);
+            } else {
+                fail(1);
+            }
+        },
+        '2': function (src, chan) {
+            reloadScripts();
+            // Using the same script id shouldn't reset objects
+            print("TestSESSION: State #2");
+            if (SESSION.hasUser(src) && SESSION.hasChannel(chan) && SESSION.users(src).messageSent === true) {
+                tests.session.state[3](src, chan);
+            } else {
+                fail(2);
+            }
+        },
+        '3': function (src, chan) {
+            reloadScripts();
+            // Objects should be reset if the script id is changed
+            print("TestSESSION: State #3");
+            if (SESSION.hasUser(src) && SESSION.hasChannel(chan) && SESSION.users(src).messageSent === false && SESSION.global().messageSent === false) {
+                success();
+            } else {
+                fail(3);
+            }
+        }
+    }
+};
+
+({
+afterChatMessage: function (src, message, chan) {
+    if (message.substr(0, 6) === "Test: ") {
+        tests[message.substr(6)].run(src, chan);
+    }
+}
+})

--- a/tests/server/main.cpp
+++ b/tests/server/main.cpp
@@ -5,6 +5,7 @@
 #include "testvariation.h"
 #include "testregister.h"
 #include "testban.h"
+#include "testsession.h"
 
 int main(int argc, char *argv[])
 {
@@ -17,6 +18,7 @@ int main(int argc, char *argv[])
     runner.addTest(new TestVariation());
     runner.addTest(new TestRegister());
     runner.addTest(new TestBan());
+    runner.addTest(new TestSESSION());
     runner.start();
 
     return a.exec();

--- a/tests/server/server.pro
+++ b/tests/server/server.pro
@@ -33,7 +33,8 @@ SOURCES += main.cpp \
     testvariation.cpp \
     ../common/pokemontestrunner.cpp \
     testregister.cpp \
-    testban.cpp
+    testban.cpp \
+    testsession.cpp
 
 HEADERS += \
     ../common/test.h \
@@ -45,4 +46,5 @@ HEADERS += \
     testvariation.h \
     ../common/pokemontestrunner.h \
     testregister.h \
-    testban.h
+    testban.h \
+    testsession.h

--- a/tests/server/testban.cpp
+++ b/tests/server/testban.cpp
@@ -7,6 +7,7 @@ void TestBan::run()
 {
     createAnalyzer();
     createAnalyzer();
+    QTimer::singleShot(5000, this, SLOT(reject()));
 }
 
 void TestBan::onPlayerConnected()

--- a/tests/server/testsession.cpp
+++ b/tests/server/testsession.cpp
@@ -1,0 +1,25 @@
+#include <PokemonInfo/teamholder.h>
+#include <Teambuilder/analyze.h>
+
+#include "testsession.h"
+
+void TestSESSION::onPlayerConnected()
+{
+    Analyzer *analyzer = sender();
+
+    TeamHolder holder;
+    holder.name() = "TheUnknownOne";
+
+    analyzer->login(holder, false);
+    analyzer->sendChanMessage(0, "Test: session");
+    QTimer::singleShot(5000, this, SLOT(reject()));
+}
+
+void TestSESSION::onChannelMessage(const QString &message, int, bool)
+{
+    if (message == "fail") {
+        reject();
+    } else if (message == "accept") {
+        accept();
+    }
+}

--- a/tests/server/testsession.h
+++ b/tests/server/testsession.h
@@ -1,0 +1,13 @@
+#ifndef TESTSESSION_H
+#define TESTSESSION_H
+
+#include "testplayer.h"
+class TestSESSION : public TestPlayer
+{
+    Q_OBJECT
+public slots:
+    void onPlayerConnected();
+    void onChannelMessage(const QString &message, int chan, bool html);
+};
+
+#endif // TESTSESSION_H


### PR DESCRIPTION
This is for Beta's scripts in particular, though maybe I might consider using it myself now.

It fixes data being reset between reloads as well as identifyScriptAs behavior (clearing all players & channels when the scriptid is changed but not refilling). I'm pretty sure you know what I'm talking about :x

It's quite aggressive and not very efficient, probably needs some changes here and there.

Also adds a bunch of methods for scripts (clearAll, disableAll, refill, hasUser, hasChannel, dump)
