### PR TITLE
Rototiller & Flower Shield Fixes

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -6934,14 +6934,24 @@ struct MMVenomDrench : public MM {
 
 struct MMFlowerShield : public MM {
     MMFlowerShield() {
+        functions["BeforeTargetList"] = &btl;
         functions["UponAttackSuccessful"] = &uas;
     }
 
+    /* Copied from Haze*/
+    static void btl(int s, int, BS &b) {
+        if (tmove(b,s).power == 0) {
+            b.targetList.clear();
+            b.targetList.push_back(s);
+        }
+    }
     static void uas(int s, int, BS &b) {
-        foreach (int p, b.sortedBySpeed())
-        {
-            if (b.hasType(p, Type::Grass)) {
-                b.inflictStatMod(p, Defense, 1, s);
+        if (tmove(b,s).power == 0) {
+            foreach (int p, b.sortedBySpeed())
+            {
+                if (b.hasType(p, Type::Grass)) {
+                    b.inflictStatMod(p, Defense, 1, s);
+                }
             }
         }
     }
@@ -6953,7 +6963,7 @@ struct MMRototiller : public MM {
         functions["UponAttackSuccessful"] = &uas;
     }
 
-    /* Copied from Haze to correctly interact with Pressure */
+    /* Copied from Haze*/
     static void btl(int s, int, BS &b) {
         if (tmove(b,s).power == 0) {
             b.targetList.clear();


### PR DESCRIPTION
Only supposed to be 1 stage on all grounded, grass type pokemon. Previously affected all Grass pokemon and boosted X times, where X is adjacent pokemon that can be tilled 

http://pokemon-online.eu/forums/showthread.php?23625-rototiller-gives-more-than-1
