### PR TITLE
po:setmsg and po:appendmsg

### DIFF
--- a/src/Teambuilder/channel.cpp
+++ b/src/Teambuilder/channel.cpp
@@ -177,6 +177,12 @@ void Channel::anchorClicked(const QUrl &url)
         } else if (path.leftRef(5) == "send/") {
             QString msg = path.mid(5);
             client->sendMessage(msg, myid);
+        } else if (path.leftRef(7) == "setmsg/") {
+            QString msg = path.mid(7);
+            client->getLineEdit()->setText(msg);
+        } else if (path.leftRef(10) == "appendmsg/") {
+            QString msg = path.mid(10);
+            client->getLineEdit()->setText(client->getLineEdit()->text() + msg);
         }
     } else {
         QDesktopServices::openUrl(url);

--- a/src/Teambuilder/client.cpp
+++ b/src/Teambuilder/client.cpp
@@ -583,6 +583,11 @@ QString Client::defaultChannel()
     return globals.value(QString("DefaultChannels/%1").arg(relay().getIp())).toString();
 }
 
+QIRCLineEdit* Client::getLineEdit()
+{
+    return myline;
+}
+
 void Client::addChannel(const QString &name, int id)
 {
     m_channelNames.insert(id, name);

--- a/src/Teambuilder/client.h
+++ b/src/Teambuilder/client.h
@@ -126,6 +126,7 @@ public:
     void disableBattleWindow(int id);
 
     void onDisconnection();
+    QIRCLineEdit* getLineEdit();
 
     QList<QIcon> statusIcons;
     QIcon chatot, greychatot;


### PR DESCRIPTION
Though these might not seem that interesting at first (certainly not as useful as po:send), they can be pretty helpful for, say, an html control panel (sendHtmlAll). Perhaps you'd like to enter a reason for the mute/kick (and therefore `po:setmsg//kick [name]:`, so you can enter a reason easily).

Again, not super useful, but it will find its purpose.
