### PR TITLE
Revert to old SESSION global behavior

### DIFF
--- a/src/Server/scriptengine.cpp
+++ b/src/Server/scriptengine.cpp
@@ -258,6 +258,8 @@ void ScriptEngine::changeScript(const QString &script, const bool triggerStartUp
         if(triggerStartUp) {
             serverStartUp();
         }
+
+        mySessionDataFactory->refill(SessionDataFactory::ConstructGlobal);
     }
 }
 

--- a/src/Server/sessiondatafactory.h
+++ b/src/Server/sessiondatafactory.h
@@ -19,7 +19,8 @@ public:
     enum RefillType {
         RefillAll,
         RefillUsers,
-        RefillChannels
+        RefillChannels,
+        ConstructGlobal
     };
 
     Q_INVOKABLE void registerUserFactory(QScriptValue factoryFunction);
@@ -44,6 +45,7 @@ private:
     bool userFactoryEnabled;
     bool channelFactoryEnabled;
     bool globalFactoryEnabled;
+    bool globalFactoryConstructed;
     QString currentScriptId;
     QScriptValue globalFactoryFunction;
     QScriptValue globalFactoryStorage;

--- a/tests/data/server/scripts.js
+++ b/tests/data/server/scripts.js
@@ -41,7 +41,7 @@ tests.session = {
             reloadScripts();
             // Using the same script id shouldn't reset objects
             print("TestSession: State #2");
-            if (SESSION.hasUser(src) && SESSION.hasChannel(chan) && SESSION.users(src).messageSent === true) {
+            if (SESSION.hasUser(src) && SESSION.hasChannel(chan) && SESSION.users(src).messageSent === true && typeof SESSION.global().uptime === 'number') {
                 tests.session.state[3](src, chan);
             } else {
                 fail(2);
@@ -51,7 +51,7 @@ tests.session = {
             reloadScripts();
             // Objects should be reset if the script id is changed
             print("TestSession: State #3");
-            if (SESSION.hasUser(src) && SESSION.hasChannel(chan) && SESSION.users(src).messageSent === false && SESSION.global().messageSent === false) {
+            if (SESSION.hasUser(src) && SESSION.hasChannel(chan) && SESSION.users(src).messageSent === false && SESSION.global().messageSent === false && typeof SESSION.global().uptime === 'undefined') {
                 success();
             } else {
                 fail(3);
@@ -61,6 +61,9 @@ tests.session = {
 };
 
 ({
+serverStartUp: function () {
+    SESSION.global().uptime = +sys.time();
+},
 afterChatMessage: function (src, message, chan) {
     if (message.substr(0, 6) === "Test: ") {
         tests[message.substr(6)].run(src, chan);


### PR DESCRIPTION
This makes it so the global factory storage for SESSION isn't reset every time a handler is passed. To update the global storage, change the script id, or call SESSION.clearAll() and register your script and factories again.

Currently, it constructs the global factory after calling serverStartUp (this was the exact old behavior), but it's possible to do this right away (after the handler is passed).

Fixes #881.
