### PR TITLE
+20 BP to Gen 6 Natural Gift

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -5391,8 +5391,8 @@ struct MMNaturalGift :  public MM
         }
 
         b.eatBerry(s);
-
-        tmove(b, s).power = tmove(b, s).power * ItemInfo::BerryPower(berry);
+        //Natural gift gets a 20 BP boost in Gen 6
+        tmove(b, s).power = tmove(b, s).power * (ItemInfo::BerryPower(berry) + (b.gen() >= 6 ? 20 : 0));
         tmove(b,s).type = ItemInfo::BerryType(berry);
         turn(b,s)["NaturalGiftOk"] = true;
     }


### PR DESCRIPTION
You were AFK so I went with the super easy/lazy way of doing it. If you'd prefer, we can create berry_pow for all gens and have to load it per gen

"As of Pokémon X & Pokémon Y, the power has been increased by 20 for each Berry, while the types have remained the same"
