### PR TITLE
Unknown extraneous whitespace character after Kee

### DIFF
--- a/bin/db/items/berries.txt
+++ b/bin/db/items/berries.txt
@@ -63,7 +63,7 @@
 62 Jaboca Berry
 63 Rowap Berry
 64 Roseli Berry
-65 Kee Berry	
+65 Kee Berry
 66 Maranga Berry
 1000 PRZCureBerry
 1001 Mint Berry


### PR DESCRIPTION
Not sure what it was, but it wasn't needed that I could see and it messed with my json. Most likely it's a tab character but cba to look further into it.
