### PR TITLE
Mega Stone Behavior Fix

### DIFF
--- a/bin/db/abilities/ability_messages.txt
+++ b/bin/db/abilities/ability_messages.txt
@@ -69,3 +69,4 @@
 117 %s reversed all other Pokémon's auras!
 118 %s's Bulletproof blocked the attack!
 120 %s is levitating!
+121 %s's Sticky Hold made the attack ineffective!|%s's Sticky Hold prevented item loss!

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -607,8 +607,8 @@ BattleChoices BattleSituation::createChoice(int slot)
         }
     }
 
-    if (ItemInfo::isMegaStone(poke(slot).item()) && ItemInfo::MegaStoneForme(poke(slot).item()).original() == poke(slot).num()
-            && hasWorkingItem(slot, poke(slot).item()) && !megas[player(slot)]) {
+    //Mega Evolution is not hindered by Embargo, etc.
+    if (ItemInfo::isMegaStone(poke(slot).item()) && ItemInfo::MegaStoneForme(poke(slot).item()).original() == poke(slot).num() && !megas[player(slot)]) {
         ret.mega = true;
     }
 
@@ -834,8 +834,8 @@ void BattleSituation::analyzeChoices()
         if (choice(i).attackingChoice() || choice(i).moveToCenterChoice()) {
             int slot = i;
             if (choice(slot).mega()) {
-                if (ItemInfo::isMegaStone(poke(slot).item()) && ItemInfo::MegaStoneForme(poke(slot).item()).original() == poke(slot).num()
-                        && hasWorkingItem(slot, poke(slot).item())) {
+                //Mega Evolution is not hindered by Embargo, etc.
+                if (ItemInfo::isMegaStone(poke(slot).item()) && ItemInfo::MegaStoneForme(poke(slot).item()).original() == poke(slot).num()) {
                     sendItemMessage(66, slot, 0, 0, 0, ItemInfo::MegaStoneForme(poke(slot).item()).toPokeRef());
                     changeForme(player(slot), slotNum(slot), ItemInfo::MegaStoneForme(poke(slot).item()));
                     megas[player(slot)] = true;


### PR DESCRIPTION
Fixes the following:
-Sticky Hold has a message that should display when stuff fails
-Mega Evolving shouldn't be prevented by Embargo, etc.
-Sticky Hold should block Berry loss on Bug Bite, etc.
-Fling should not fling your correct Mega Stone
-Knock Off should be boosted against Sticky hold, but not make them lose item
-Trick should fail if either Pokemon is going to obtain their correct stone
-Bestow should fail if it gives the opponent their correct stone
-Covet, etc. should fail if it grants the attacker their correct stone

Anything that involves giving, losing, or gaining the wrong stone should work as if it was any other standard item.
