### PR TITLE
Wonder Guard + FS/DD fix

### DIFF
--- a/bin/db/abilities/ability_messages.txt
+++ b/bin/db/abilities/ability_messages.txt
@@ -43,7 +43,7 @@
 67 %s is carelessly slacking off!
 68 %s's %a raised its attack!|%s's %a made the attack useless!
 70 %s's %a absorbs the attack!|%s's %a made the attack useless!
-71 %s's Wonder Guard evades the attack!
+71 %s's Wonder Guard blocks the attack!
 74 %s lost part of its armor!
 78 %s stole %f's %i!
 80 %a sharply raised %s's Attack!|%a sharply raised %s's Defense!|%a sharply raised %s's Sp. Att.!|%a sharply raised %s's Sp. Def.!|%a sharply raised %s's Speed!

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1570,6 +1570,10 @@ struct MMDoomDesire : public MM
                         b.notify(BS::All, BattleCommands::Effective, s, quint8(0));
                         return;
                     }
+                    if ((b.rawTypeEff(MoveInfo::Type(slot(b,s)["DoomDesireMove"].toInt(), b.gen()), s) <= 0) && b.hasWorkingAbility(s, Ability::WonderGuard) && b.gen() >= 5) {
+                        b.sendAbMessage(71,0,s);
+                        return;
+                    }
                     fturn(b,s).stab = slot(b,s)["DoomDesireStab"].toInt();
                     turn(b,s)["AttackStat"] = slot(b,s)["DoomDesireAttack"];
                     fturn(b,s).remove(TM::CriticalHit);


### PR DESCRIPTION
"The foe's X avoided damage by using Wonder Guard!" is the message used in 4th gen, but that could imply secondary effects like Paralysis from Thunderbolt could still happen, which isn't correct. 

And with DD/FS, it says "X took the Future Sight" "X's Wonder Guard evades the attack!" so you "take" but you also "evade"

Blocks is short, sweet, and works in all cases.
