### PR TITLE
Lang/Credits in Server window instead of just Registry

### DIFF
--- a/src/Teambuilder/client.cpp
+++ b/src/Teambuilder/client.cpp
@@ -1473,6 +1473,11 @@ QMenuBar * Client::createMenuBar(MainEngine *w)
     connect(dontUseNicknames, SIGNAL(triggered(bool)), SLOT(changeNicknames(bool)));
     dontUseNicknames->setChecked(globals.value("Battle/NoNicknames").toBool());
 
+    w->addLanguageMenu(menuBar);
+
+    QMenu *helpMenu = menuBar->addMenu(tr("&About"));
+    helpMenu->addAction(tr("&Credits"), w, SLOT(launchCredits()));
+
     mymenubar = menuBar;
 
     return menuBar;


### PR DESCRIPTION
Changing languages while connected to a server didn't exhibit any odd behavior, some people might not entirely notice JUST on the registry window. So it makes the sim a bit more user friendly to always be there.

Then since Credits are being updated to add PkParaiso and such, I though we should make them a bit more prominent. 

I split it just in case you didn't want to change this, or wanted it done differently. 
