### PR TITLE
Adding lastkoedturn to Assurance Mech

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -3550,7 +3550,7 @@ void BattleSituation::requestSwitchIns()
             koedPlayers.insert(player(i));
             koedPokes.insert(i);
 
-            if (gen() >= 5) {
+            if (gen() >= 4) {
                 /* For Get Even. */
                 teamMemory(player(i))["LastKoedTurn"] = turn();
             }

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -173,8 +173,8 @@ struct MMAssurance : public MM
     }
 
     static void bcd(int s, int t, BS &b) {
-        if (turn(b,t).contains("DamageTaken")) {
-            tmove(b, s).power = tmove(b, s).power * 2;
+        if (turn(b,t).contains("DamageTaken") || (team(b, b.player(t)).contains("LastKoedTurn") && team(b, b.player(t))["LastKoedTurn"].toInt() == b.turn() - 1)) {
+                    tmove(b, s).power = tmove(b, s).power * 2;
         }
     }
 };


### PR DESCRIPTION
Adding where after a KO, Assurance doubles, like Retaliate, along with changing the gen for LastKoedTurn so Assurance mechanic applies to Gen 4 as well
