### PR TITLE
Protect + Storm Drain / Lightning Rod fix

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -1165,7 +1165,7 @@ struct AMLightningRod : public AM {
     AMLightningRod() {
         functions["GeneralTargetChange"] = &gtc;
         functions["OpponentBlock"] = &ob;
-        functions["DetermineAttackFailure"] =&daf
+        functions["DetermineAttackFailure"] = &daf;
     }
 
     static void gtc(int s, int t, BS &b) {


### PR DESCRIPTION
Lightning Rod/Storm Drain doesn't increase Sp. Attack if the opponent uses Protect.

http://pokemon-online.eu/forums/showthread.php?23800-Protect-Storm-Drain

I think that this should work, but I am not sure. :/
