### PR TITLE
Berry fixes, small Belch fix, 4G Fling Fix

### DIFF
--- a/bin/db/items/berry_effects.txt
+++ b/bin/db/items/berry_effects.txt
@@ -9,9 +9,9 @@
 8 1-0#Lum
 9 3-30#pinch Sitrus
 10 13-1#Figy--Bold, Calm, Modest, Timid (-Att)
-11 13-4#Wiki--Adamant, Careful, Impish, Jolly (-SpA)
-12 13-3#Mago--Brave, Quiet, Relaxed, Sassy (-Spe)
-13 13-5#Aguav--Lax, Naive, Naughty, Rash (-SpDef)
+11 13-3#Wiki--Adamant, Careful, Impish, Jolly (-SpA)
+12 13-5#Mago--Brave, Quiet, Relaxed, Sassy (-Spe)
+13 13-4#Aguav--Lax, Naive, Naughty, Rash (-SpDef)
 14 13-2#Iapapa---Gentle, Hasty, Lonely, Mild (-Def)
 35 4-9
 36 4-10

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1147,9 +1147,10 @@ bool BattleSituation::testAccuracy(int player, int target, bool silent)
     //OHKO
     int move  = turnMemory(player)["MoveChosen"].toInt();
 
-    if (pokeMemory(player).value("BerryLock").toBool()) {
-        pokeMemory(player).remove("BerryLock");
-        if (gen() <= 4 || !MoveInfo::isOHKO(move, gen()))
+    //Micle Berry only guarantees next hit in Gen 4 (bar OHKO)
+    if (turnMemory(player).value("BerryLock").toBool()) {
+        turnMemory(player).remove("BerryLock");
+        if (!MoveInfo::isOHKO(move, gen()))
             return true;
     }
 
@@ -1189,6 +1190,7 @@ bool BattleSituation::testAccuracy(int player, int target, bool silent)
 
     turnMemory(player).remove("Stat6ItemModifier");
     turnMemory(player).remove("Stat6AbilityModifier");
+    turnMemory(player).remove("Stat6BerryModifier");
     turnMemory(target).remove("Stat7ItemModifier");
     turnMemory(target).remove("Stat7AbilityModifier");
     callieffects(player,target,"StatModifier");
@@ -1208,7 +1210,8 @@ bool BattleSituation::testAccuracy(int player, int target, bool silent)
             * (20-turnMemory(target).value("Stat7ItemModifier").toInt())/20
             * (20+turnMemory(player).value("Stat6AbilityModifier").toInt())/20
             * (20+turnMemory(player).value("Stat6PartnerAbilityModifier").toInt())/20
-            * (20-turnMemory(target).value("Stat7AbilityModifier").toInt())/20;
+            * (20-turnMemory(target).value("Stat7AbilityModifier").toInt())/20
+            * (20+turnMemory(player).value("Stat6BerryModifier)").toInt())/20;
 
     if (coinflip(unsigned(acc), 100)) {
         return true;
@@ -3366,6 +3369,8 @@ void BattleSituation::devourBerry(int p, int berry, int s)
     if (hasWorkingAbility(s, Ability::CheekPouch)) {
         healLife(s, poke(s).totalLifePoints()/3);
     }
+
+    pokeMemory(p)["BerryEaten"] = true;
 
     /* Restoring initial conditions */
     pokeMemory(p)["ItemArg"] = tempItemStorage;

--- a/src/BattleServer/berries.cpp
+++ b/src/BattleServer/berries.cpp
@@ -395,7 +395,11 @@ struct BMBerryLock : public BMPinch
             return;
         }
 
-        poke(b,s)["BerryLock"] = true;
+        if (b.gen() <= 4) {
+            turn(b,s)["BerryLock"] = true;
+        } else {
+            turn(b,s)["Stat6BerryModifier"] = 4;
+        }
         b.sendBerryMessage(10,s,0);
     }
 };
@@ -410,10 +414,13 @@ struct BMCustap : public BMPinch
         if (!b.isOut(p)) {
             return;
         }
+        if (turn(b,p).value("BugBiter").toBool()) {
+            b.eatBerry(s);
+            return;
+        }
         if (!testpinch(p, s, b, 4, false)) {
             return;
         }
-
         b.sendBerryMessage(11,s,0);
         turn(b,s)["TurnOrder"] = 3;
     }
@@ -458,7 +465,7 @@ struct BMConfuseBerry : public BMPinch
     }
 
     static void tp (int p, int s, BS &b) {
-        if (b.koed(s) || b.poke(s).isFull())
+        if (b.koed(s))
             return;
 
         if (!testpinch(p, s, b, 4, true))
@@ -471,7 +478,7 @@ struct BMConfuseBerry : public BMPinch
         int plus = NatureInfo::StatBoosted(b.poke(s).nature());
         int minus = NatureInfo::StatHindered(b.poke(s).nature());
         if (plus != minus) {
-            int arg = poke(b,p)["ItemArg"].toInt();
+            int arg = poke(b,s)["ItemArg"].toInt();
             if (arg == minus)
                 b.inflictConfused(s,s);
         }


### PR DESCRIPTION
If you have any questions on anything, please ask.

One thing that "looks" wrong is the Stat6BerryModifier... But if you Fling a Micle Berry at your target who is holding a Wide Lens, it would overwrite each other (Since Wide Lens is Stat6ItemModifier). The chances of this ever happening are extremely low, and it would only affect like 4-6 moves... But you know SOMEONE would eventually find it... and I'm already in there anyway...
