### PR TITLE
Store Choice Data for Embargo/MagicRoom/Klutz

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -977,7 +977,7 @@ void BattleSituation::callEntryEffects(int player)
     if (!koed(player)) {
         /* Various problems with item setting up are:
            - WhiteHerb restoring baton pass stats
-           - Chesto Berry not having an argument and curing Toxic Spikes
+           - Pecha Berry not having an argument and curing Toxic Spikes
            - Choice Scarf not activating right at weather starting
 
            So All those must be taken in account when changing something to
@@ -2149,6 +2149,9 @@ void BattleSituation::acquireAbility(int play, int ab, bool firstTime) {
 
 void BattleSituation::loseAbility(int slot)
 {
+    /* For when Klutz is lost. Only this line is needed otherwise the Choice memory will never reset.*/
+    pokeMemory(slot)["ChoiceMemory"] = pokeMemory(slot)["LastMoveUsed"];
+
     callaeffects(slot, slot, "OnLoss");
 }
 

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1624,6 +1624,9 @@ struct MMEmbargo : public MM
     }
 
     static void uas(int s, int t, BS &b) {
+        /* Choice Memory */
+        poke(b,t)["ChoiceMemory"] = poke(b,t)["LastMoveUsed"];
+
         b.sendMoveMessage(32,0,s,type(b,s),t);
         poke(b,t)["Embargoed"] = true;
         poke(b,t)["EmbargoEnd"] = b.turn() + 4;
@@ -1635,8 +1638,12 @@ struct MMEmbargo : public MM
             b.sendMoveMessage(32,1,s,0);
             poke(b,s)["Embargoed"] = false;
             b.removeEndTurnEffect(BS::PokeEffect, s, "Embargo");
-            //White Herb activates right now if there are negative stats
+
+            /* White Herb and Choice Memory */
             b.callieffects(s, s, "AfterStatChange");
+            if (!poke(b,s).contains("ChoiceMemory") || poke(b,s).value("ChoiceMemory").toInt() == 0) {
+                poke(b,s)["ChoiceMemory"] = poke(b,s)["LastMoveUsed"];
+            }
         }
     }
 };
@@ -5650,7 +5657,19 @@ struct MMMagicRoom : public MM {
             b.sendMoveMessage(156,1,s,Pokemon::Psychic);
             b.battleMemory().remove("MagicRoomCount");
             b.removeEndTurnEffect(BS::FieldEffect, 0, "MagicRoom");
+
+            /* White Herb and Choice Memory */
+            foreach (int p, b.sortedBySpeed()) {
+                b.callieffects(p, p, "AfterStatChange");
+                if (!poke(b,p).contains("ChoiceMemory") || poke(b,p).value("ChoiceMemory").toInt() == 0) {
+                    poke(b,p)["ChoiceMemory"] = poke(b,p)["LastMoveUsed"];
+                }
+            }
         } else {
+            /* Choice Memory */
+            foreach (int p, b.sortedBySpeed()) {
+                poke(b,p)["ChoiceMemory"] = poke(b,p)["LastMoveUsed"];
+            }
             b.sendMoveMessage(156,0,s,Pokemon::Psychic);
             b.battleMemory()["MagicRoomCount"] = 5;
             b.addEndTurnEffect(BS::FieldEffect, bracket(b.gen()), 0, "MagicRoom", &et);
@@ -5663,9 +5682,13 @@ struct MMMagicRoom : public MM {
             b.sendMoveMessage(156,1,s,Pokemon::Psychic);
             b.battleMemory().remove("MagicRoomCount");
             b.removeEndTurnEffect(BS::FieldEffect, 0, "MagicRoom");
-            //White Herb activates right now if there are negative stats
+
+            /* White Herb and Choice Memory */
             foreach (int p, b.sortedBySpeed()) {
                 b.callieffects(p, p, "AfterStatChange");
+                if (!poke(b,p).contains("ChoiceMemory") || poke(b,p).value("ChoiceMemory").toInt() == 0) {
+                    poke(b,p)["ChoiceMemory"] = poke(b,p)["LastMoveUsed"];
+                }
             }
         }
     }


### PR DESCRIPTION
Things to note (Waiting on mechanics tests for the two things above before I "fix" them.):
Speed ties/Scarves and cancelling Magic Room early causes Choice memory to be overwritten,
Multi-Turn moves starting right as Magic Room ends will overwrite the Choice memory

Everything else is storing and retrieving choice memory properly (Klutz, Embargo, and Magic Room), which is a vast improvement over what we had!
