### PR TITLE
Fix Min/Max stats in tooltip for Gen.1/2

### DIFF
--- a/src/libraries/BattleManager/auxpokedataproxy.cpp
+++ b/src/libraries/BattleManager/auxpokedataproxy.cpp
@@ -87,7 +87,7 @@ int AuxPokeDataProxy::maxStat(int stat)
     int boost = statBoost(stat);
 
     if (pokemon()->gen().num <=2) {
-        return (PokemonInfo::Stat(pokemon()->num(), pokemon()->gen(), stat, pokemon()->level(), 31, 255))
+        return (PokemonInfo::Stat(pokemon()->num(), pokemon()->gen(), stat, pokemon()->level(), 15, 255))
                 * PokeFraction(std::max(2+boost, 2), std::max(2-boost, 2));
     } else {
         return (PokemonInfo::Stat(pokemon()->num(), pokemon()->gen(), stat, pokemon()->level(), 31, 255) * 11/10)


### PR DESCRIPTION
Tooltip should ignore Natures when calculating the Min/Max stats for
Gen.1/2
