### PR TITLE
Me First + Multiturn move

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -4110,7 +4110,7 @@ struct MMMeFirst : public MM
     }
 
     static void daf(int s, int t, BS &b) {
-        /* if has moved or is using a multi-turn move */
+        /* if has moved */
         if (b.koed(t) || fturn(b,t).contains(TM::HasMoved)) {
             fturn(b,s).add(TM::Failed);
             return;


### PR DESCRIPTION
Being that Me First can copy any turn of MultiTurn moves, removing the block for it fixes the issue, as it applies to every gen. 
