### PR TITLE
RagePowder/FollowMe Fix

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -2072,13 +2072,24 @@ struct MMFollowMe : public MM
         addFunction(b.battleMemory(), "GeneralTargetChange", "FollowMe", &gtc);
     }
 
+    struct FM : public QSet<int> {
+        FM() {
+                //Follow Me prevents attraction by all 2-Turn moves
+                (*this) << NoMove << Bounce << Dig << Dive << Fly << FocusPunch << Geomancy << IceBurn
+                                  << ShadowForce << SkullBash << SkyAttack << SkyDrop << SolarBeam << RazorWind
+                                  << FreezeShock << PhantomForce;
+
+        }
+    };
+    static FM forbidden_moves;
+
     static void gtc(int s, int, BS &b) {
         int tar = b.opponent(b.player(s));
 
         if (team(b, tar)["FollowMeTurn"] != b.turn())
             return;
         int target = team(b, tar)["FollowMePlayer"].toInt();
-        if (b.koed(target) || !poke(b, target).contains("FollowMe") || b.player(s) == b.player(target))
+        if (b.koed(target) || !poke(b, target).contains("FollowMe") || b.player(s) == b.player(target) || forbidden_moves.contains(move(b,s)))
             return;
 
         int tarChoice = tmove(b,s).targets;
@@ -2102,6 +2113,8 @@ struct MMFollowMe : public MM
         turn(b,s)["Target"] = target;
     }
 };
+//Declaring satic class variable
+MMFollowMe::FM MMFollowMe::forbidden_moves;
 
 struct MMGravity : public MM
 {


### PR DESCRIPTION
This one fix is just adding a QSet so you don't have to list every Two-Turn move in the target determination because super long things are stupid, but the moves aren't supposed to draw two-turn moves, so yeah.. 
Anyway, this is going to be a multi-commit fix so I would /prefer/ this not be immediately closed, but if something is wrong in the code a comment would be nice in order to fix it, since there are 5 issues with these moves, yet some are difficult to do so not doing it all right now. 
Your choice though, coyo.~
