### PR TITLE
Fix reducing effect of Aura Break

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -2049,7 +2049,7 @@ struct AMAura : public AM {
         }
         for (int i = 0; i < b.numberOfSlots(); i++) {
             if (!b.koed(i) && b.hasWorkingAbility(i, Ability::AuraBreak)) {
-                boost = -boost;
+                boost = -5;
             }
         }
 


### PR DESCRIPTION
Aura Break reduces the damage by 25% and not 30%.
