### PR TITLE
Metronome Fix for 3G/5G

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -2237,7 +2237,8 @@ struct MMMetronome : public MM
                 continue;
             }
 
-            bool correctMove = !b.hasMove(s,move) && ((b.gen() <= 4 && !MMAssist::forbidden_moves.contains(move, b.gen())) ||
+            //3G and 5G allow Metronome to call a move the user knows. 2G/4G/6G do not allow this.
+            bool correctMove = (!b.hasMove(s,move) || b.gen() == 5 || b.gen() == 3) && ((b.gen() <= 4 && !MMAssist::forbidden_moves.contains(move, b.gen())) ||
                                                       (b.gen() >= 5 && !forbidden.contains(move, b.gen())));
 
             if (correctMove) {


### PR DESCRIPTION
If you want it less bloated, I'll let you handle that. There's too much to change, too many places a simple check can be reversed and then Metronome is bugged far worse than it was before. Its fine as it is, and all gens 2~6 are handled correctly now, so the only time we'll change it is when 7th Gen comes out, if even that.

If it was any other move, I'd do it. But Metronome takes far too long to ensure it's not bugged. No sense in creating more bugs when we've got a bug-free fix here.
