### PR TITLE
colour buttons fix + reload themes

### DIFF
--- a/src/Teambuilder/Teambuilder/trainermenu.cpp
+++ b/src/Teambuilder/Teambuilder/trainermenu.cpp
@@ -356,7 +356,7 @@ void TrainerMenu::on_colorButton_clicked()
 {
     QColor c = QColorDialog::getColor(team().color());
 
-    if (c.isValid() && (c.lightness() > 140 || c.green() > 180)) {
+    if (!c.isValid() || (c.isValid() && (c.lightness() > 140 || c.green() > 180))) { // So they can click cancel without their colour disappearing!
         return;
     }
 

--- a/src/Teambuilder/loadwindow.cpp
+++ b/src/Teambuilder/loadwindow.cpp
@@ -86,7 +86,7 @@ void LoadWindow::on_colorButton_clicked()
 {
     QColor c = QColorDialog::getColor(holder.profile().color());
 
-    if (c.isValid() && (c.lightness() > 140 || c.green() > 180)) {
+    if (!c.isValid() || (c.isValid() && (c.lightness() > 140 || c.green() > 180))) { // So they can click cancel without their colour disappearing!
         return;
     }
 

--- a/src/Teambuilder/mainwindow.cpp
+++ b/src/Teambuilder/mainwindow.cpp
@@ -681,6 +681,7 @@ void MainEngine::rebuildThemeMenu()
 
     themeMenu->addSeparator();
     themeMenu->addAction(tr("Reload &StyleSheet"), this, SLOT(loadStyleSheet()), tr("Ctrl+D", "Reload Stylesheet"));
+    themeMenu->addAction(tr("Reload &Themes"), this, SLOT(reloadThemes()));
     themeMenu->addSeparator();
     themeMenu->addAction(tr("&Get more themes..."), this, SLOT(openThemesForum()));
 }
@@ -693,6 +694,11 @@ void MainEngine::changeUserThemeFolder()
     if (dir != "") {
         s.setValue("Themes/Directory", dir + "/");
     }
+    rebuildThemeMenu();
+}
+
+void MainEngine::reloadThemes()
+{
     rebuildThemeMenu();
 }
 

--- a/src/Teambuilder/mainwindow.h
+++ b/src/Teambuilder/mainwindow.h
@@ -59,6 +59,7 @@ private slots:
     void openPluginConfiguration();
     void changeTheme();
     void changeUserThemeFolder();
+    void reloadThemes();
 
     void updateDataReady(const QString &data, bool error);
     void changeLogReady(const QString &data, bool error);


### PR DESCRIPTION
Users can now click cancel when selected a colour and not have it
seemingly disappear, and reload the themes from the current themes
folder instead of re-selecting it
