### PR TITLE
Fixed taunt/magic bounce bug + counters decreasing after bounce

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1471,7 +1471,7 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
     }
 
     turnMem(player).add(TurnMemory::HasMoved);
-    if (gen() >= 5) {
+    if (gen() >= 5 && !battleMemory().value("CoatingAttackNow").toBool()) {
         counters(player).decreaseCounters();
     }
 

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -3299,9 +3299,10 @@ struct MMTaunt : public MM
     }
 
     static void mp(int s, int, BS &b) {
-        if (!b.counters(s).hasCounter(BC::Taunt)) {
+        if (!b.counters(s).hasCounter(BC::Taunt) || !b.battleMemory().value("CoatingAttackNow").toBool()) {
             return;
         }
+
         int move = turn(b,s)["MoveChosen"].toInt();
         if (move != NoMove && MoveInfo::Power(move, b.gen()) == 0) {
             turn(b,s)["ImpossibleToMove"] = true;


### PR DESCRIPTION
Fixes a bug where if you're taunted and have Magic Bounce, and the opp uses a bounce-able move, it fails.
