### PR TITLE
Storm Drain + Protect fix

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -812,6 +812,9 @@ struct AMMotorDrive : public AM {
     }
 
     static void op(int s, int t, BS &b) {
+        if (b.isProtected(s, t))
+            return;
+
         if (type(b,t) == Type::Electric) {
             turn(b,s)[QString("Block%1").arg(b.attackCount())] = true;
             b.sendAbMessage(41,0,s,s,Pokemon::Electric);
@@ -1142,6 +1145,9 @@ struct AMVoltAbsorb : public AM {
     }
 
     static void op(int s, int t, BS &b) {
+        if (b.isProtected(s, t))
+            return;
+
         if (type(b,t) == poke(b,s)["AbilityArg"].toInt() && (b.gen() >= 4 || tmove(b,t).power > 0) ) {
             if (!(poke(b, s).value("HealBlockCount").toInt() > 0)) {
                 //HealBlock removes the absorbing effect
@@ -1206,7 +1212,7 @@ struct AMLightningRod : public AM {
     }
 
     static void ob(int s, int t, BS &b) {
-        if (b.gen() <= 4)
+        if (b.gen() <= 4 || b.isProtected(s, t))
             return;
 
         int tp = type(b,t);
@@ -1318,6 +1324,9 @@ struct AMSapSipper : public AM {
     }
 
     static void uodr(int s, int t, BS &b) {
+        if (b.isProtected(s, t))
+            return;
+
         int tp = type(b,t);
 
         if (tp == poke(b,s)["AbilityArg"].toInt()) {

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -2815,6 +2815,16 @@ bool BattleSituation::hasGroundingEffect(int player)
             || (gen() >= 3 && pokeMemory(player).value("Rooted").toBool()) || pokeMemory(player).value("SmackedDown").toBool();
 }
 
+bool BattleSituation::isProtected(int player, int t)
+{
+    // check to see if protected //
+    return pokeMemory(player).value("ProtectiveMoveTurn", -1).toInt() == turn()
+            || (teamMemory(this->player(player)).value("WideGuardUsed", -1).toInt() == turn()
+                && (tmove(t).targets == Move::Opponents
+                    || tmove(t).targets == Move::All
+                    || tmove(t).targets == Move::AllButSelf));
+}
+
 void BattleSituation::changeStatus(int player, int status, bool tell, int turns)
 {
     if (poke(player).status() == status) {

--- a/src/BattleServer/battle.h
+++ b/src/BattleServer/battle.h
@@ -131,6 +131,7 @@ public:
     bool isFlying(int player);
     bool hasFlyingEffect(int player); //returns true if has flying effect outside of flying type
     bool hasGroundingEffect(int player); //returns true for gravity, ingrain, ...
+    bool isProtected(int player, int t);
     void requestSwitchIns();
     void requestEndOfTurnSwitchIns();
     void requestSwitch(int player, bool entryEffects=true);


### PR DESCRIPTION
fixed bug where if you had absorbing ability and used protect, you would still absorb

function isProtected checks to see if you've used a protecting move or one of your allies has used wide guard and the move is multitargeted
i don't think i've missed any circumstances! and i think this is better than re-ordering since this will be unaffected by any further re-orderings (plus the function comes in handy for any more absorbing abilities released in the future) :)
