### PR TITLE
Sport Fail Check/End effect/Gen 6 reduction

### DIFF
--- a/bin/db/moves/move_message.txt
+++ b/bin/db/moves/move_message.txt
@@ -57,7 +57,7 @@
 84 %s identified %f!
 86 %ts's team became shrouded in mist!|%ts's Mist wore off!|The mist prevents %f from having its stats lowered!
 87 %s regained health!|%s regained a lot of health!|%s regained little health!
-88 Electric's power has been weakened!|Fire's power has been weakened!
+88 Electric's power has been weakened!|Fire's power has been weakened!|The effects of Water Sport have faded.|The effects of Mud Sport have faded.
 92 %s began having a nightmare!|%s is locked in a nightmare!
 93 %s calmed down!|%s became confused due to fatigue!
 94 The battlers shared their pain!

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -188,6 +188,7 @@ void BattleSituation::initializeEndTurnFunctions()
         21.4 Tailwind ends
         21.5 Lucky Chant ends
         21.6 Water Pledge + Fire Pledge ends, Fire Pledge + Grass Pledge ends, Grass Pledge + Water Pledge ends
+        21.7 Sport Ends (assumed, Gen 6+)
 
         22.0 Gravity ends
 
@@ -3025,8 +3026,8 @@ int BattleSituation::calculateDamage(int p, int t)
         }
     } else {
         QString sport = "SportedEnd" + QString::number(type);
-        if (battleMemory().contains(sport) && battleMemory().value(sport).toInt() > turn()) {
-            power /= 2;
+        if (battleMemory().contains(sport) && battleMemory().value(sport).toInt() > 0) {
+            power = power * 2 / 3;
         }
     }
 

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -4369,6 +4369,18 @@ struct MMMudSport : public MM
 {
     MMMudSport() {
         functions["UponAttackSuccessful"] = &uas;
+        functions["DetermineAttackFailure"] = &daf;
+    }
+
+    static ::bracket bracket(Pokemon::gen) {
+        return makeBracket(21, 7) ;
+    }
+
+    static void daf(int s, int, BS &b) {
+        int type = turn(b,s)["MudSport_Arg"].toInt();
+        if (b.battleMemory()["SportedEnd"+ QString::number(type)].toInt() > 0 || poke(b,s)["Sported" + QString::number(type)] == true) {
+            fturn(b,s).add(TM::Failed);
+        }
     }
 
     static void uas(int s, int, BS &b) {
@@ -4379,7 +4391,24 @@ struct MMMudSport : public MM
             poke(b,s)["Sported" + QString::number(type)] = true;
             b.battleMemory()["Sported"+ QString::number(type)] = s;
         } else {
-            b.battleMemory()["SportedEnd"+ QString::number(type)] = b.turn() + 5;
+            b.battleMemory()["SportedEnd"+ QString::number(type)] = 5;
+            b.addEndTurnEffect(BS::FieldEffect, bracket(b.gen()), 0, "SportedEnd"+ QString::number(type), &et);
+        }
+    }
+
+    static void et(int s, int, BS &b) {
+        inc(b.battleMemory()["SportedEnd9"], -1);
+        if (b.battleMemory()["SportedEnd9"].toInt() == 0) {
+            b.sendMoveMessage(88,2,s,Pokemon::Water);
+            b.battleMemory().remove("SportedEnd9");
+            b.removeEndTurnEffect(BS::FieldEffect, 0, "SportedEnd9");
+        }
+
+        inc(b.battleMemory()["SportedEnd12"], -1);
+        if (b.battleMemory()["SportedEnd12"].toInt() == 0) {
+            b.sendMoveMessage(88,3,s,Pokemon::Ground);
+            b.battleMemory().remove("SportedEnd12");
+            b.removeEndTurnEffect(BS::FieldEffect, 0, "SportedEnd12");
         }
     }
 };


### PR DESCRIPTION
I'm completely tired of this code, but I can't figure out how to make it so it only deducts ONCE. Right now, if you have Mud Sport and Water Sport up at the same time, they only last 3 turns.

I've tried turn and battle memory restrictions, I've tried making different `&et` functions with different brackets, everything.

This is FAR better than what we have currently, where it doesn't even end. No one even uses these moves, let alone both at the same time.

If you could provide some insight on how to fix the double deduction, please do. Otherwise, this is as far as I go with this fix. I'm not wasting another 4 hours trying everything except the thing that makes it work just to get it to work :(
