### PR TITLE
Cheek Pouch + Natural gift fixes

### DIFF
--- a/bin/db/abilities/ability_messages.txt
+++ b/bin/db/abilities/ability_messages.txt
@@ -71,3 +71,4 @@
 120 %s is levitating!
 122 %s's Sticky Hold made the attack ineffective!|%s's Sticky Hold prevented item loss!
 124 %s gave its %i to %f!
+125 %s's Cheek Pouch provided extra nutrients to restore HP!

--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -2483,5 +2483,6 @@ void AbilityEffect::init()
     REGISTER_AB(121, Aerilate);
     //122 Sticky Hold message
     REGISTER_AB(123, Klutz);
-    REGISTER_AB(124, Symbiosis)
+    REGISTER_AB(124, Symbiosis);
+    //125 Cheek pouch message
 }

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -3348,6 +3348,7 @@ void BattleSituation::eatBerry(int player, bool show) {
         sendItemMessage(8000,player,0, 0, berry);
 
         if (hasWorkingAbility(player, Ability::CheekPouch)) {
+            sendAbMessage(125,0,player);
             healLife(player, poke(player).totalLifePoints()/3);
         }
 

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -5507,7 +5507,8 @@ struct MMNaturalGift :  public MM
             return;
         }
 
-        b.eatBerry(s);
+        //False is used to prevent Cheek Pouch and Belch from seeing that a berry was eaten but still allow Harvest to work
+        b.eatBerry(s, false);
         //Natural gift gets a 20 BP boost in Gen 6
         tmove(b, s).power = tmove(b, s).power * (ItemInfo::BerryPower(berry) + (b.gen() >= 6 ? 20 : 0));
         tmove(b,s).type = ItemInfo::BerryType(berry);


### PR DESCRIPTION
There's no actual message in game for Cheek pouch, just shows "Dedenne's Cheek Pouch" then restores HP. So I wrote one that tells the players what is occurring, otherwise it just randomly recovers HP with no notification.

Also Cheek Pouch doesn't work with Natural Gift, nor should Belch (Fixing a bug and found another bug that gets fixed the same way)
