### PR TITLE
Feint fixes + improvements(?)

### DIFF
--- a/bin/db/moves/move_message.txt
+++ b/bin/db/moves/move_message.txt
@@ -25,6 +25,7 @@
 32 %f can't use items anymore!|%s can use items again!
 33 %s's Encore ended!|%f received an encore!
 35 %s endured the hit!|%s braced itself!
+42 %f's protection was broken!|%f's King's Shield was broken!|%f's Spiky Shield was broken!|%ts's team's Crafty Shield was broken!|%ts's team's Mat Block was broken!|%ts's team's Wide Guard was broken!|%ts's team's Quick Guard was broken!
 43 %s's Sturdy made the attack fail!|It's a one hit KO!
 45 %s flung its %i!
 46 %s is getting pumped!


### PR DESCRIPTION
Random extra line breaks made it look awkward when collapsed
Also fixed a typo in a comment (Very important ok?) and finally localized "Fast Guard" to "Quick Guard"

What this fixes:
-Actually breaks Kings Shield and Spiky Shield
-Displays a message if it breaks Protect/Detect

The only things this does "worse" than what we had:
-Crafty Shield break will show in Normal color, rather than Dark (Should have been Fairy anyway)
-Mat Block will never show a message anyway, so it could be whatever color you want and no one would ever see it (Feint has priority over Mat block, which only lasts 1 turn, making color and message irrelevant right now)
