### PR TITLE
Corrected Imposter mechanics

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -1525,9 +1525,9 @@ struct AMImposter : public AM
     }
 
     static void us(int s, int , BS &b) {
-        int t = b.randomOpponent(s);
+        int t = b.slot(b.opponent(b.player(s)), b.slotNum(s)); // directly across
 
-        if (t == -1)
+        if (b.koed(t))
             return;
 
         if (fpoke(b,t).flags & BS::BasicPokeInfo::Transformed || b.hasSubstitute(t))


### PR DESCRIPTION
From Bulbapedia:
In Double and Triple Battles, Imposter will copy the opponent in the position directly opposite it. If there is no opponent directly opposite to it, it will not transform.

(This was also confirmed here: http://pokemon-online.eu/threads/imposter-in-double-triple-battles.27190/#post-378049)

Made it so Ditto transforms into the poke it's facing, and made it so it doesn't transform if there's no poke there.
