### PR TITLE
Outrage + Disable/Cursed Body + Confuse fix

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -5340,8 +5340,7 @@ struct MMOutrage : public MM
             MoveEffect::setup(poke(b,s)["OutrageMove"].toInt(),s,s,b);
 
             if (b.gen() >= 5) {
-                addFunction(turn(b, s), "AfterAttackSuccessful", "Outrage", &aas);
-                addFunction(turn(b, s), "AttackSomehowFailed", "Outrage", &aas);
+                addFunction(turn(b, s), "AfterAttackFinished", "Outrage", &aas);
             }
         }
     }


### PR DESCRIPTION
Also, if you have any advice on how to allow Disable to hit a "forced" move... such as Turn 2+3 of Outrage, or the recharge turn of Hyperbeam/similar, let me know, since that's a bug as well
