### PR TITLE
Download and Magic Guard fixes

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -2251,7 +2251,7 @@ void BattleSituation::inflictRecoil(int source, int target)
             if (gen().num < 5 && tmove(source).attack == Move::DreamEater) {
                 if (canHeal(source,HealByMove,Move::DreamEater))
                     healLife(source, damage);
-            } else {
+            } else if (!hasWorkingAbility(source, Ability::MagicGuard)){
                 sendMoveMessage(1,2,source,Pokemon::Poison,target);
                 inflictDamage(source,damage,source,false);
 
@@ -3745,7 +3745,7 @@ int BattleSituation::getBoostedStat(int player, int stat)
         if (pokeMemory(player).contains("PowerTricked") && (stat == 1 || stat == 2)) {
             givenStat = 3 - stat;
         }
-        /* Wonder room: attack & sp attack switched, 5th gen */
+        /* Wonder room: defense & sp defense switched*/
         if (battleMemory().contains("WonderRoomCount") && (stat == 2 || stat == 4)) {
             stat = 6 - stat;
             givenStat = 6 - givenStat;


### PR DESCRIPTION
Gen 4 Download resolves at like 6 different points, but the only useful ones are UponSetup, EndTurn, and BeforeTargetList. 

The rest are impossible to recreate (or redundant) in a Gen 4 setting:
-There's no possible way to have the ability not activate before your attack, but then activate after your attack, on the same turn. 
-The "opponent switching in" is irrelevant because the only thing it would affect is Imposter, a Gen 5 ability. 
-Then there's no way to have it not resolve as the turn starts, but then resolve when the Pokemon actually goes to attack, on the same turn.

Gen 4 also applies the stats of dead pokemon. Gen 5 and on do not.
