### PR TITLE
Confuse Damage Formula rewrite

### DIFF
--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -1870,13 +1870,35 @@ void BattleBase::inflictConfusedDamage(int player)
 {
     notify(All, StatusMessage, player, qint8(HurtConfusion));
 
-    tmove(player).type = Pokemon::Curse;
-    tmove(player).power = 40;
-    tmove(player).attack = Move::NoMove;
-    turnMem(player).typeMod = 0;
-    turnMem(player).stab = 2;
-    tmove(player).category = Move::Physical;
-    int damage = calculateDamage(player, player);
+    //tmove(player).type = Pokemon::Curse;
+    //tmove(player).power = 40;
+    //tmove(player).attack = Move::NoMove;
+    //turnMem(player).typeMod = 0;
+    //turnMem(player).stab = 2;
+    //tmove(player).category = Move::Physical;
+
+    int power = 40;
+    int level = fpoke(player).level;
+    int att = fpoke(player).stats[Attack] *getStatBoost(player, Attack);
+    int def = fpoke(player).stats[Defense] *getStatBoost(player, Defense);
+
+    //Gen 4 Confuse gets boosted by Helping Hand (1.5x)
+    if (gen() == 4 && turnMemory(player).contains("HelpingHand")) {
+        power = 60;
+    }
+
+    int randnum;
+    int damage;
+    if (gen().num == 1) {
+        randnum = randint(38) + 217;
+        damage = (((std::min(((level * 2 / 5) + 2) * power, 65535) *
+                   att / def) / 50) + 2) * randnum/255;
+    } else {
+        randnum = randint(16) + 85;
+        damage = (((std::min(((level * 2 / 5) + 2) * power, 65535) *
+                   att / 50) / def))*randnum/100;
+    }
+
     inflictDamage(player, damage, player, true, gen() <= 1); //in RBY the damage is to the sub
 }
 


### PR DESCRIPTION
Sample from one of the tests I did. This was the shortest unedited log. I tested to make sure it varied (Diggersby did 71, 73, and 85 this battle. Furret did 101, 107, and killed itself)

The main thing is, Confuse should not be boosted by anything except stat boosts (no abilities, no weather, no items, etc). except in Gen 4 where it gets Helping Hand. It should also not be reduced by Reflect/etc. 

What I did was: Took the "calculateDamage" function call and killed it. Then I went into that function and only grabbed the lines of code that mattered: The core damage formula and variation. 

Long story short, no more unintended 1.5x~2x damage confuse hits.

```
Start of turn 1
The foe's Klefki used Swagger!
Diggersby's Attack sharply rose!
Diggersby became confused!

Diggersby is confused!
Diggersby used Cut!
It's not very effective...
A critical hit!
The foe's Klefki lost 38% of its health!

Start of turn 2
The foe's Klefki used Iron Defense!
The foe's Klefki's Defense sharply rose!

Diggersby is confused!
It hurt itself in its confusion!
Diggersby lost 82 HP! (21% of its health)

Fuzzysqurl: +2 252+ Atk Diggersby Return vs. 252 HP / 0 Def Diggersby: 71-84 (18.9 - 22.4%) -- possible 5HKO

Start of turn 3
Fuzzysqurl called Diggersby back!
Fuzzysqurl sent out Furret!

The foe's Klefki used Swagger!
Furret's Attack sharply rose!
Furret became confused!

Start of turn 4
The foe's Klefki used Iron Defense!
The foe's Klefki's Defense sharply rose!

Furret is confused!
It hurt itself in its confusion!
Furret lost 113 HP! (30% of its health)

Fuzzysqurl: +2 252+ Atk Furret Tackle vs. 252 HP / 0 Def Furret: 97-115 (25.9 - 30.7%) -- guaranteed 4HKO
```
