### PR TITLE
Future Sight shouldn't fail on initial turn

### DIFF
--- a/bin/db/moves/3G/special_effect.txt
+++ b/bin/db/moves/3G/special_effect.txt
@@ -2,7 +2,7 @@
 12 43#Guillotine
 13 104-0#razor wind
 18 107#whirlwind
-19 13-3_16*2_239*2_327_87_542_479#Fly
+19 13-3_16*2_239*2_327_87_542_479_248_353#Fly
 20 10#bind-inflict damage every turn
 23 126#stomp
 26 64#jump kick
@@ -28,7 +28,7 @@
 83 10#Fire spin
 87 152#Thunder
 90 43#Fissure
-91 13-1_89*2_222*2#Dig
+91 13-1_89*2_222*2_248_353#Dig
 99 102#rage
 101 91#night shade
 102 81#mimic
@@ -151,7 +151,7 @@
 288 54#grudge
 289 118#snatch
 290 110#secret power
-291 13-2_57*2#dive
+291 13-2_57*2_248_353#dive
 293 17#camouflage
 300 88-12#mud sport
 301 66#ice ball
@@ -166,7 +166,7 @@
 329 43#sheer cold
 335 12#block, aka mean look
 338 11#frenzy plant
-340 13-0_16*2_239*2_327_87_542_479#bounce
+340 13-0_16*2_239*2_327_87_542_479_353_248#bounce
 343 23#covet
 346 88-9#water sport
 353 29#doom desire

--- a/bin/db/moves/4G/special_effect.txt
+++ b/bin/db/moves/4G/special_effect.txt
@@ -2,7 +2,7 @@
 12 43#Guillotine
 13 104-0#razor wind
 18 107#whirlwind
-19 13-3_16*2_239*2_327_87_542_479#Fly
+19 13-3_16*2_239*2_327_87_542_479_248_353#Fly
 20 10#bind-inflict damage every turn
 23 126#stomp
 26 64#jump kick
@@ -28,7 +28,7 @@
 83 10#Fire spin
 87 152#Thunder
 90 43#Fissure
-91 13-1_89*2_222*2#Dig
+91 13-1_89*2_222*2_248_353#Dig
 99 102#rage
 101 91#night shade
 102 81#mimic
@@ -151,7 +151,7 @@
 288 54#grudge
 289 118#snatch
 290 110#secret power
-291 13-2_57*2#dive
+291 13-2_57*2_248_353#dive
 293 17#camouflage
 300 88-12#mud sport
 301 66#ice ball
@@ -166,7 +166,7 @@
 329 43#sheer cold
 335 12#block, aka mean look
 338 11#frenzy plant
-340 13-0_16*2_239*2_327_87_542_479#bounce
+340 13-0_16*2_239*2_327_87_542_479_248_353#bounce
 343 23#covet
 346 88-9#water sport
 353 29#doom desire
@@ -227,4 +227,4 @@
 461 61#Lunar dance
 462 24#crush grip
 463 10#magma storm
-467 13-4#shadow force
+467 13-4_248_353#shadow force

--- a/bin/db/moves/5G/special_effect.txt
+++ b/bin/db/moves/5G/special_effect.txt
@@ -2,7 +2,7 @@
 12 43#Guillotine
 13 104-0#razor wind
 18 107#whirlwind
-19 13-3_16*2_239*2_327_87_542_479#Fly
+19 13-3_16*2_239*2_327_87_542_479_248_353#Fly
 20 10#bind-inflict damage every turn
 23 126#stomp
 26 64#jump kick
@@ -28,7 +28,7 @@
 83 10#Fire spin
 87 152#Thunder
 90 43#Fissure
-91 13-1_89*2_222*2#Dig
+91 13-1_89*2_222*2_248_353#Dig
 99 102#rage
 101 91#night shade
 102 81#mimic
@@ -151,7 +151,7 @@
 288 54#grudge
 289 118#snatch
 290 110#secret power
-291 13-2_57*2#dive
+291 13-2_57*2_248_353#dive
 293 17#camouflage
 300 88-12#mud sport
 301 66#ice ball
@@ -166,7 +166,7 @@
 329 43#sheer cold
 335 12#block, aka mean look
 338 11#frenzy plant
-340 13-0_16*2_239*2_327_87_542_479#bounce
+340 13-0_16*2_239*2_327_87_542_479_248_353#bounce
 343 23#covet
 346 88-9#water sport
 353 29#doom desire
@@ -227,7 +227,7 @@
 461 61#Lunar dance
 462 24#crush grip
 463 10#magma storm
-467 13-4#shadow force
+467 13-4_248_353#shadow force
 469 169#Wide guard
 470 155-2_4#Guard Share
 471 155-1_3#Power Share

--- a/bin/db/moves/6G/special_effect.txt
+++ b/bin/db/moves/6G/special_effect.txt
@@ -2,7 +2,7 @@
 12 43#Guillotine
 13 104-0#razor wind
 18 107#whirlwind
-19 13-3_16*2_239*2_327_87_542_479_18#Fly
+19 13-3_16*2_239*2_327_87_542_479_18_248_353#Fly
 20 10#bind-inflict damage every turn
 23 126#stomp
 26 64#jump kick
@@ -30,7 +30,7 @@
 83 10#Fire spin
 87 152#Thunder
 90 43#Fissure
-91 13-1_89*2_222*2#Dig
+91 13-1_89*2_222*2_248_353#Dig
 99 102#rage
 101 91#night shade
 102 81#mimic
@@ -155,7 +155,7 @@
 288 54#grudge
 289 118#snatch
 290 110#secret power
-291 13-2_57*2#dive
+291 13-2_57*2_248_353#dive
 293 17#camouflage
 300 88-12#mud sport
 301 66#ice ball
@@ -170,7 +170,7 @@
 329 43#sheer cold
 335 12#block, aka mean look
 338 11#frenzy plant
-340 13-0_16*2_239*2_327_87_542_479#bounce
+340 13-0_16*2_239*2_327_87_542_479_248_353#bounce
 343 23#covet
 346 88-9#water sport
 353 29#doom desire
@@ -232,7 +232,7 @@
 461 61#Lunar dance
 462 24#crush grip
 463 10#magma storm
-467 13-4#shadow force
+467 13-4_248_353#shadow force
 469 169#Wide guard
 470 155-2_4#Guard Share
 471 155-1_3#Power Share
@@ -288,7 +288,7 @@
 567 157-11#Forest's Curse
 569 104-6#Geomancy
 571 10#Infestation
-578 13-4#phantom force
+578 13-4_248_353#phantom force
 581 157-7#Trick or Treat
 584 200#Belch
 588 201#Electriy Terrain

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1585,6 +1585,10 @@ struct MMDoomDesire : public MM
         {
             b.removeEndTurnEffect(BS::SlotEffect, s, "DoomDesire");
 
+            //Invulnerable Check needed to interact with DB files for proper move execution.
+            if(poke(b,s).value("Invulnerable").toBool()) {
+                slot(b,s)["DoomDesireFailed"] = true;
+            }
             if (slot(b,s)["DoomDesireFailed"].toBool()) {
                 int move = slot(b,s)["DoomDesireMove"].toInt();
                 b.sendMoveMessage(29,0,s,MoveInfo::Type(move, b.gen()),s,move);


### PR DESCRIPTION
https://github.com/po-devs/pokemon-online/pull/1155
But fixing the new bug it would create.

This is probably the easiest and quickest way to do it, I tried a few other ways and found moderate success, but they had many more lines changed making it more complicated, and weren't as effective as this.

Essentially, we make Future Sight + Doom Desire work on Flying/Digging/etc targets, but then before it hits, turn the success into a fail at the last moment if they are invulnerable, allowing one to set up the move properly now.
