### PR TITLE
Sub + Fling fixes

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -2020,7 +2020,7 @@ struct MMFling : public MM
 {
     MMFling() {
         functions["DetermineAttackFailure"] = &daf;
-        functions["OnFoeOnAttack"] = &uas;
+        functions["UponAttackSuccessful"] = &uas;
         functions["BeforeTargetList"] = &btl;
         functions["AttackSomehowFailed"] = &asf;
     }
@@ -2051,6 +2051,10 @@ struct MMFling : public MM
 
     static void uas (int s, int t, BS &b) {
         int item = b.poke(s).item();
+        if (b.hasSubstitute(t) && !b.canBypassSub(t)) {
+            b.disposeItem(s);
+            return;
+        }
         if (!b.koed(t)) {
             bool isEmbargoed = poke(b, t).value("Embargoed").toBool();
             if (!ItemInfo::isBerry(item)) {


### PR DESCRIPTION
Item should be disposed if it hits a substitute, as the attack is successful. 

UponAttackSuccessful + small code handling sub makes it work and dispose properly. The sub will block the side effects, but still cause the user to dispose their item.
