### PR TITLE
transform fixes

### DIFF
--- a/src/BattleServer/rbymoves.cpp
+++ b/src/BattleServer/rbymoves.cpp
@@ -935,13 +935,16 @@ struct RBYTransform : public MM
 
         po.id = num;
         po.weight = PokemonInfo::Weight(num);
-        po.type1 = PokemonInfo::Type1(num, b.gen());
-        po.type2 = PokemonInfo::Type2(num, b.gen());
+        //For Type changing moves
+        po.types = b.getTypes(t);
+        //po.type1 = PokemonInfo::Type1(num, b.gen());
+        //po.type2 = PokemonInfo::Type2(num, b.gen());
 
         b.changeSprite(s, num);
 
         for (int i = 0; i < 4; i++) {
             b.changeTempMove(s,i,b.move(t,i));
+            if (b.move(t,i) == Move::NoMove) { continue; }
             b.changePP(s, i, 5);
         }
 


### PR DESCRIPTION
wasn't copying the typing, so fixed that 
it was also allowing the use of No Move, ie if a Pokemon has 2 moves and you transform into it, you can use those 2 moves along with the 2 No Move slots, so fixed that.
