### PR TITLE
Adv Search in TB + TB color fix

### DIFF
--- a/bin/Themes/Classic/default.css
+++ b/bin/Themes/Classic/default.css
@@ -432,6 +432,10 @@ PokeEdit QLabel {
     color: white;
 }
 
+PokeEdit QProgressBar {
+    color: white;
+}
+
 TeamMenu QRadioButton, TeamMenu QCheckBox, TeamMenu QGroupBox {
     color: white;
 }
@@ -472,6 +476,11 @@ PokeSelection QPushButton#altForme {
 PokeSelection QPushButton#changeSpecies {
     color: white;
     background: #3975b8;
+}
+
+PokeSelection QPushButton#advSearch {
+    color: white;
+    background: #885EAD;
 }
 
 /**** box ****/

--- a/bin/Themes/Dark Classic/default.css
+++ b/bin/Themes/Dark Classic/default.css
@@ -437,6 +437,10 @@ PokeEdit QLabel {
     color: white;
 }
 
+PokeEdit QProgressBar {
+    color: white;
+}
+
 TeamMenu QRadioButton, TeamMenu QCheckBox, TeamMenu QGroupBox {
     color: white;
 }
@@ -477,6 +481,11 @@ PokeSelection QPushButton#altForme {
 PokeSelection QPushButton#changeSpecies {
     color: white;
     background: #3975b8;
+}
+
+PokeSelection QPushButton#advSearch {
+    color: white;
+    background: #885EAD;
 }
 
 /**** box ****/

--- a/src/libraries/TeambuilderLibrary/pokeselection.cpp
+++ b/src/libraries/TeambuilderLibrary/pokeselection.cpp
@@ -49,6 +49,7 @@ PokeSelection::PokeSelection(Pokemon::uniqueId pokemon, QAbstractItemModel *poke
     connect(ui->pokemonList, SIGNAL(pokemonActivated(Pokemon::uniqueId)), SLOT(finish()));
     connect(ui->changeSpecies, SIGNAL(clicked()), SLOT(finish()));
     connect(ui->pokemonFrame, SIGNAL(clicked()), SLOT(toggleSearchWindow()));
+    connect(ui->advSearch, SIGNAL(clicked()), SLOT(toggleSearchWindow()));
 }
 
 void PokeSelection::toggleSearchWindow()

--- a/src/libraries/TeambuilderLibrary/pokeselection.ui
+++ b/src/libraries/TeambuilderLibrary/pokeselection.ui
@@ -166,6 +166,16 @@
      </item>
     </layout>
    </item>
+   <item row="6" column="1" colspan="2">
+    <widget class="QPushButton" name="advSearch">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Advanced Search</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
People were complaining it wasn't visible enough, even to a point where a brief argument broke out in Tohjo because some people couldn't find it. Clicking the Sprite will still open Advanced search and now so will the button.

Classic: http://i.imgur.com/Z0aG6d9.png
Dark Classic: http://i.imgur.com/ncd3S2x.png

Also, if you notice on Dark Classic especially, you can read what the Base Stat numbers are!
