### PR TITLE
6G Sky Drop Weight Limit

### DIFF
--- a/bin/db/moves/move_message.txt
+++ b/bin/db/moves/move_message.txt
@@ -8,7 +8,7 @@
 10 %s was hurt by %m!|%s is freed from %m!|%f became trapped by swirling magma!
 11 %s must recharge!
 12 %f can no longer escape!
-13 %s sprang up!|%s burrowed its way under the ground!|%s hid underwater!|%s flew high up!|%s vanished instantly!|%s took %f in the air!|%s can't attack while in the air!
+13 %s sprang up!|%s burrowed its way under the ground!|%s hid underwater!|%s flew high up!|%s vanished instantly!|%s took %f in the air!|%s can't attack while in the air!|But %s is too heavy to be lifted...
 14 %s shattered %tf's team protections!
 16 %s stole and ate %f's %i!
 17 %s transformed into the %t type!

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1842,8 +1842,7 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
                     }
                     callaeffects(target, player, "UponOffensiveDamageReceived");
                     callieffects(target, player, "UponBeingHit");
-                    /*This allows many items and effects to be triggered by Knock off
-                     *The only mechanical error now is Red Card/Eject button not activating */
+                    /*This allows Knock off to work*/
                     calleffects(player, target, "KnockOff");
                 }
 

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1303,6 +1303,11 @@ struct MMBounce : public MM
                 b.notify(BS::All, BattleCommands::UseAttack, s, qint16(Move::SkyDrop));
                 fturn(b,s).add(TM::Failed);
             }
+            //Gen 6 puts limit on Sky drop at 200kg / 440.9 lbs.
+            if (b.gen() >= 6 && move(b,s) == Move::SkyDrop && b.weight(t) >= 200) {
+                b.notify(BS::All, BattleCommands::UseAttack, s, qint16(Move::SkyDrop));
+                b.fail(s, 13, 7, Pokemon::Flying, t);
+            }
         } else {
             /* Second part of the move */
             if (move(b,s) == Move::SkyDrop) {


### PR DESCRIPTION
In game it just says "But it failed"

Veteran Padgett (tester) and I both agreed it should let the user know why it failed.

```
Start of turn 1
Smeargle used Sky Drop!
But the foe's Groudon is too heavy to be lifted...
```

Also, behavior regarding Red Card/Eject Button and Knock Off are correct. Removing comment that states there is an error.
