### PR TITLE
Beat Up Crit Fix

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1797,12 +1797,12 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
                 }
 
                 if (tmove(player).power > 1) {
-                    testCritical(player, target);
                     calleffects(player, target, "BeforeHitting");
                     if (turnMemory(player).contains("HitCancelled")) {
                         turnMemory(player).remove("HitCancelled");
                         continue;
                     }
+                    testCritical(player, target);
                     int damage = calculateDamage(player, target);
                     inflictDamage(target, damage, player, true);
                     hitcount += 1;


### PR DESCRIPTION
Not sure why it would check for a crit before it determines if the hit is even valid or not... HitCancelled is only used in Beat Up too, so not too much to test here.
