### PR TITLE
GSC Boost fix

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1851,7 +1851,10 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
                     callaeffects(player, target, "AfterKoing");
 
                 /* Secondary effect of an attack: like ancient power, acid, thunderbolt, ... */
-                applyMoveStatMods(player, target);
+                /* In Gen 2, KOing a pokemon won't provide any beneficial boosts*/
+                if (gen() > 2 || !koed(target)) {
+                    applyMoveStatMods(player, target);
+                }
 
                 /* For berries that activate after taking damage */
                 callieffects(target, target, "TestPinch");


### PR DESCRIPTION
Source: http://www.upokecenter.com/content/pokemon-gold-version-silver-version-and-crystal-version-timing-notes
"2. If the attack has an additional effect such as a stat stage modification, poisoning, or burning, the probability of the effect happening is now determined. If a random integer from 0 through 255 is less than the attack’s additional effect chance, the additional effect will occur. For instance, for Blizzard, there is a 51/256 chance the opposing Pokémon will become frozen. `The additional effect won’t occur if the opposing Pokémon faints because of damage, even if the attack is Ancientpower, Metal Claw, or Steel Wing.`"

Obviously you can't inflict status or drop stats on a dead Pokemon, but the self boost wasn't affected by the opponent KOing.
Tested in Gen 2 to confirmed the change took effect, and again in Gen 6 to confirm nothing got changed.
