### PR TITLE
Sand Attack + Rototiller fixes

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -2327,7 +2327,7 @@ struct AMLevitate : public AM
     }
 
     static void uodr(int s, int t, BS &b) {
-        if (type(b,t) == Type::Ground && b.isFlying(s)) {
+        if (type(b,t) == Type::Ground && b.isFlying(s) && move(b,t) != Move::Sand_Attack) {
             turn(b,s)[QString("Block%1").arg(b.attackCount())] = true;
 
             b.sendAbMessage(120, 0, s);

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -7145,14 +7145,20 @@ struct MMRototiller : public MM {
         }
     }
     static void uas(int s, int, BS &b) {
+        bool boosted = false;
         if (tmove(b,s).power == 0) {
             foreach (int p, b.sortedBySpeed())
             {
                 if (b.hasType(p, Type::Grass) && !b.isFlying(p)) {
                     b.inflictStatMod(p, Attack, 1, s);
                     b.inflictStatMod(p, SpAttack, 1, s);
+                    boosted = true;
                 }
             }
+        }
+        //If nothing happens, the user should get feedback.
+        if (!boosted) {
+            b.notify(BS::All, BattleCommands::Failed, s);
         }
     }
 };


### PR DESCRIPTION
Sand attack hits Levitating
Rototiller should "fail" if nothing gets a boost
