### PR TITLE
Beat Up user fix

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1968,11 +1968,13 @@ struct MMBeatUp : public MM {
     }
 
     static void bh(int s, int, BS &b) {
-        if (b.poke(b.player(s), b.repeatCount()).status() != Pokemon::Fine) {
-            turn(b,s)["HitCancelled"] = true;
-        } else {
-            tmove(b,s).power = 5 + (PokemonInfo::BaseStats(fpoke(b,s).id, b.gen()).baseAttack()/10);
-            //turn(b,s)["UnboostedAttackStat"] = b.poke(s, b.repeatCount()).normalStat(Attack);
+        for (int i = 0; i < 6; i++) {
+            if (b.poke(b.player(s), b.repeatCount()).status() == Pokemon::Fine || b.isOut(s, i)) {
+                tmove(b,s).power = 5 + (PokemonInfo::BaseStats(fpoke(b,s).id, b.gen()).baseAttack()/10);
+                //turn(b,s)["UnboostedAttackStat"] = b.poke(s, b.repeatCount()).normalStat(Attack);
+            } else {
+                turn(b,s)["HitCancelled"] = true;
+            }
         }
     }
 };


### PR DESCRIPTION
I'm not exactly sure why this works, but it does. It was like my 70th attempt at fixing this, spent almost an hour working on it before I realized there were 2 different status checks.

The bug was as follows:
At first glance: Beat Up hits X times, where X is the number of Pokemon you have in your party that aren't afflicted with a status.  However, the user of Beat Up always contributes, regardless of status. So Beat Up is essentially 1 + Y (where Y = X -1, and it represents the same thing X did). The User of Beat Up ignores the status check.

Jargon from UPC: `number of pokemons except user itself in your team that does not have a non-volatile status + 1`

I tested in Singles, Doubles, and Triples, and it always produced the correct amount of hits.
