### PR TITLE
Remove battleConnectionLost event from sys

### DIFF
--- a/src/Server/scriptengine.h
+++ b/src/Server/scriptengine.h
@@ -145,6 +145,8 @@ public:
     bool beforeFindBattle(int src);
     void afterFindBattle(int src);
 
+    void battleConnectionLost();
+    
     /* Imports a module with a given name */
     Q_INVOKABLE QScriptValue import(const QString &fileName);
     /* Functions called in scripts */
@@ -548,7 +550,6 @@ signals:
     void clearTheChat();
 public slots:
     void changeScript(const QString &script, const bool triggerStartUp = false);
-    void battleConnectionLost();
 
 private slots:
     void timer();


### PR DESCRIPTION
It was listed as a public slot meaning it could be called. It's still in the script object as en event.
