### PR TITLE
Gyro Ball Crit fix

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -3440,7 +3440,7 @@ struct MMGyroBall : public MM
     static void bcd (int s, int t, BS &b) {
         bool speed = turn(b,s)["GyroBall_Arg"].toInt() == 1;
 
-        int bp = 1 + 25 * b.getStat(speed ? s : t,Speed) / b.getStat(speed ? t : s,Speed);
+        int bp = 1 + 25 * b.getBoostedStat(speed ? s : t,Speed) / b.getBoostedStat(speed ? t : s,Speed);
         bp = std::max(2,std::min(bp,150));
 
         tmove(b, s).power = tmove(b, s).power * bp;


### PR DESCRIPTION
I posted results of testing in the thread
http://pokemon-online.eu/threads/gyro-ball-critical-hits-ignore-speed-drops.26761/#post-388890

The code doesn't change anything unless a crit occurs, in which case the new code properly represents game mechanics.
