### PR TITLE
Sport End Messages

### DIFF
--- a/bin/db/moves/move_message.txt
+++ b/bin/db/moves/move_message.txt
@@ -58,7 +58,7 @@
 84 %s identified %f!
 86 %ts's team became shrouded in mist!|%ts's Mist wore off!|The mist prevents %f from having its stats lowered!
 87 %s regained health!|%s regained a lot of health!|%s regained little health!
-88 Electric's power has been weakened!|Fire's power has been weakened!
+88 Electric's power has been weakened!|Fire's power has been weakened!|The effects of Mud Sport have worn off!|The effects of Water Sport have worn off!
 92 %s began having a nightmare!|%s is locked in a nightmare!
 93 %s calmed down!|%s became confused due to fatigue!
 94 The battlers shared their pain!

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -190,6 +190,7 @@ void BattleSituation::initializeEndTurnFunctions()
         21.6 Water Pledge + Fire Pledge ends, Fire Pledge + Grass Pledge ends, Grass Pledge + Water Pledge ends
 
         22.0 Gravity ends
+        22.1 Sports End (Gen6+ only)
 
         23.0 Trick Room ends
 

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -4406,6 +4406,9 @@ struct MMMudSport : public MM
         functions["DetermineAttackFailure"] = &daf;
     }
 
+    static ::bracket bracket(Pokemon::gen) {
+        return makeBracket(22, 1);
+    }
     static void daf(int s, int, BS &b) {
         int type = turn(b,s)["MudSport_Arg"].toInt();
         QString sport = "Sported" + QString::number(type);
@@ -4428,6 +4431,21 @@ struct MMMudSport : public MM
         } else {
             QString sport = "SportedEnd" + QString::number(type);
             b.battleMemory()[sport] = b.turn() + 5;
+            if (move == MudSport) {
+                slot(b,s)["MudSport"] = b.turn() + 5;
+            } else {
+                slot(b,s)["WaterSport"] = b.turn() + 5;
+            }
+            b.addEndTurnEffect(BS::SlotEffect, bracket(b.gen()), s, "MudSport", &et);
+        }
+    }
+
+    static void et (int s, int, BS &b) {
+        if (b.turn() == slot(b,s).value("MudSport")) {
+            b.sendMoveMessage(88, 2, s, Pokemon::Ground);
+        }
+        if (b.turn() == slot(b,s).value("WaterSport")) {
+            b.sendMoveMessage(88, 3, s, Pokemon::Water);
         }
     }
 };


### PR DESCRIPTION
Idk why we kept messing around with variable QStrings and what not, there are only 2 sport moves (for now), there doesn't need to be anything THAT special yet.

(23:07:56) +Fuzzysqurl: Start of turn 6
(23:07:56) +Fuzzysqurl: The foe's Smeargle used Splash!
(23:07:56) +Fuzzysqurl: But nothing happened!
(23:07:56) +Fuzzysqurl: Smeargle used Splash!
(23:07:56) +Fuzzysqurl: But nothing happened!
(23:07:56) +Fuzzysqurl: The effects of Mud Sport have worn off!
(23:07:56) +Fuzzysqurl: The effects of Water Sport have worn off!

Both were used on Turn 1. End turn order might be off, but it really doesn't matter at that point, its far enough down that nothing would conflict.
