### PR TITLE
Beat up Fixes

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1947,19 +1947,27 @@ struct MMBeatUp : public MM {
 
     static void cad(int s, int t, BS &b) {
         int source = b.player(s);
-        int def = PokemonInfo::Stat(b.poke(t).num(), b.gen(), Defense,b.poke(t).level(),0,0);
+        //int def = PokemonInfo::Stat(b.poke(t).num(), b.gen(), Defense,b.poke(t).level(),0,0);
+        int def = PokemonInfo::BaseStats(b.poke(t).num(), b.gen()).baseDefense();
         for (int i = 0; i < 6; i++) {
             PokeBattle &p = b.poke(source,i);
             if (p.status() == Pokemon::Fine || i == b.slotNum(s)) {
-                int att = PokemonInfo::Stat(p.num(), b.gen(), Attack,p.level(),0,0);
+                //int att = PokemonInfo::Stat(p.num(), b.gen(), Attack,p.level(),0,0);
+                int att = PokemonInfo::BaseStats(p.num(), b.gen()).baseAttack();
                 int damage = (((((p.level() * 2 / 5) + 2) * 10 * att / 50) / def) + 2) * (b.randint(255-217) + 217)*100/255/100;
                 b.sendMoveMessage(7,0,s,Pokemon::Dark,t,0,p.nick());
                 if (b.hasSubstitute(t))
                     b.inflictSubDamage(t,damage,t);
                 else
                     b.inflictDamage(t,damage,t,true);
+
                 if (!fpoke(b, t).substitute()) {
-                    fpoke(b, t).remove(BS::BasicPokeInfo::HadSubstitute);
+                    if (b.gen() < 3 && fpoke(b,t).is(BS::BasicPokeInfo::HadSubstitute)){
+                        //In GSC, Beat up ends when a sub is broken
+                        break;
+                    } else {
+                        fpoke(b, t).remove(BS::BasicPokeInfo::HadSubstitute);
+                    }
                 }
             }
             if (b.koed(t))
@@ -1968,11 +1976,17 @@ struct MMBeatUp : public MM {
     }
 
     static void bh(int s, int, BS &b) {
-        if (b.poke(b.player(s), b.repeatCount()).status() != Pokemon::Fine) {
-            turn(b,s)["HitCancelled"] = true;
-        } else {
-            tmove(b,s).power = 5 + (PokemonInfo::BaseStats(fpoke(b,s).id, b.gen()).baseAttack()/10);
-            //turn(b,s)["UnboostedAttackStat"] = b.poke(s, b.repeatCount()).normalStat(Attack);
+        for (int i = 0; i < 6; i++) {
+            if (b.poke(b.player(s), b.repeatCount()).status() == Pokemon::Fine || b.isOut(s, i)) {
+                if (b.gen() < 5) {
+                    tmove(b,s).power = 10;
+                } else {
+                    tmove(b,s).power = 5 + (PokemonInfo::BaseStats(fpoke(b,s).id, b.gen()).baseAttack()/10);
+                    //turn(b,s)["UnboostedAttackStat"] = b.poke(s, b.repeatCount()).normalStat(Attack);
+                }
+            } else {
+                turn(b,s)["HitCancelled"] = true;
+            }
         }
     }
 };


### PR DESCRIPTION
http://pokemon-online.eu/threads/gsc-beat-up-is-glitched.17788/
Fixes the damage issue. I had to hand calculate Beat Up's damage, but I got it working. This fixes that one really old GSC Beat Up bug that Crystal_ brought up.
GSC Beat Up also ends when it breaks a Sub, so I added that in too.

Also fixes another issue with beat up (Saving the merge conflict for ya)

From https://github.com/po-devs/pokemon-online/pull/1174
http://pokemon-online.eu/threads/bug-of-beat-up-in-gen5.21243/

```
I'm not exactly sure why this works, but it does. It was like my 70th attempt at fixing this, spent almost an hour working on it before I realized there were 2 different status checks.

The bug was as follows:
At first glance: Beat Up hits X times, where X is the number of Pokemon you have in your party that aren't afflicted with a status. However, the user of Beat Up always contributes, regardless of status. So Beat Up is essentially 1 + Y (where Y = X -1, and it represents the same thing X did). The User of Beat Up ignores the status check.

Jargon from UPC: number of pokemons except user itself in your team that does not have a non-volatile status + 1

I tested in Singles, Doubles, and Triples, and it always produced the correct amount of hits.
```
