### PR TITLE
Thunder Wave + Normalize Fixes

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -857,7 +857,7 @@ struct AMMotorDrive : public AM {
 
 struct AMNormalize : public AM {
     AMNormalize() {
-        functions["BeforeTargetList"] = &btl;
+        functions["MoveSettings"] = &btl;
     }
 
     static void btl(int s, int, BS &b) {

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1485,6 +1485,9 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
 
     //Just for truant
     callaeffects(player, player, "DetermineAttackPossible");
+    /*Normalize, Aerilate, etc. Needs to be higher than "MovesPossible" to allow proper interaction with Ion Deluge*/
+    callaeffects(player, player, "MoveSettings");
+
     if (turnMemory(player).value("ImpossibleToMove").toBool() == true) {
         goto trueend;
     }
@@ -1915,7 +1918,8 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
                     if (Move::StatusInducingMove && tmove(player).status == Pokemon::Poisoned && hasType(target, Type::Steel)) {
                         fail = true;
                     } else if (attack == Move::ThunderWave) {
-                        if (hasType(target, Type::Ground)) {
+                        //Thunderwave is affected by immunities in all forms of battle
+                        if (ineffective(rawTypeEff(type, target))) {
                             fail = true;
                         } else if (gen() >= 6 && hasType(target, Type::Electric) &&
                                    !(hasWorkingTeamAbility(target, Ability::Lightningrod) || hasWorkingAbility(target, Ability::VoltAbsorb) || hasWorkingAbility(target, Ability::MotorDrive))) {


### PR DESCRIPTION
Normalize should occur before Ion Deluge. So a Delcatty using Thunderwave with Ion Deluge active gets treated as an Electric Move (Tested against a Rhyhorn and a Misdreavus). Tested this one myself in game.

Also, Thunder Wave should be affected by type immunities in inverted. The reason for the change before was the test that was performed in game was against something with Lightning Rod, so it wouldn't paralyzed regardless of battle mode. This inadvertently broke Normalize Thunder Wave, which was report this morning as a bug. Wriggle did the testing for this section of the fix.
