### PR TITLE
Fix Stat bar text in TB search

### DIFF
--- a/bin/Themes/Classic/default.css
+++ b/bin/Themes/Classic/default.css
@@ -432,9 +432,15 @@ PokeEdit QLabel {
     color: white;
 }
 
-PokeEdit QProgressBar {
+PokeEdit QProgressBar[style="QWindowsVistaStyle"], QProgressBar[style="QWindowsXPStyle"], QProgressBar[style="QWindowsStyle"] {
     color: white;
 }
+
+/* In case a better color is ever found
+PokeEdit QProgressBar[style="QFusionStyle"] {
+    color: black;
+}
+*/
 
 TeamMenu QRadioButton, TeamMenu QCheckBox, TeamMenu QGroupBox {
     color: white;

--- a/bin/Themes/Dark Classic/default.css
+++ b/bin/Themes/Dark Classic/default.css
@@ -437,9 +437,15 @@ PokeEdit QLabel {
     color: white;
 }
 
-PokeEdit QProgressBar {
+PokeEdit QProgressBar[style="QWindowsVistaStyle"], QProgressBar[style="QWindowsXPStyle"], QProgressBar[style="QWindowsStyle"] {
     color: white;
 }
+
+/* In case a better color is ever found
+PokeEdit QProgressBar[style="QFusionStyle"] {
+    color: black;
+}
+*/
 
 TeamMenu QRadioButton, TeamMenu QCheckBox, TeamMenu QGroupBox {
     color: white;


### PR DESCRIPTION
Attach CSS to style.
Left in the other block of code because the color changing text that Fusion has by default is a complete eyesore for base stats between 84 and 89... then again a little later (probably like 94 to 99?)
Also it helps when people are themeing to get the Style sheet name (though its pretty obvious)
