### PR TITLE
Fix SQL SecurityManager::userList() & sys.dbAll

### DIFF
--- a/src/Server/security.cpp
+++ b/src/Server/security.cpp
@@ -393,7 +393,6 @@ QStringList&& SecurityManager::userList()
 
         q.exec("select name from trainers");
 
-        QStringList ret;
         while (q.next()) {
             ret.push_back(q.value(0).toString());
         }


### PR DESCRIPTION
Previously ret was redefined, the return value was never filled with the user names.
