### PR TITLE
Fix Box withdraw gen difference

### DIFF
--- a/src/Teambuilder/Teambuilder/pokeboxes.cpp
+++ b/src/Teambuilder/Teambuilder/pokeboxes.cpp
@@ -339,8 +339,8 @@ void PokeBoxes::setCurrentTeamPoke(PokeTeam *p)
     *currentPokeTeam() = *p;
 
     if (p->gen() != team().team().gen()) {
-        p->setGen(team().team().gen());
-        p->runCheck();
+        currentPokeTeam()->setGen(team().team().gen());
+        currentPokeTeam()->runCheck();
     }
 }
 


### PR DESCRIPTION
so when you store a pokemon in one gen, then try to withdraw in another, it doesn't make your team have two gens at once (preventing you from battling)
