### PR TITLE
Fix OHKO immunity in RBY

### DIFF
--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -397,7 +397,7 @@ void BattleRBY::useAttack(int player, int move, bool specialOccurence, bool tell
         calculateTypeModStab();
 
         int typemod = turnMem(player).typeMod;
-        if (tmove(player).power > 1 && typemod < -50 && attack != Move::Bind && attack != Move::Wrap) {
+        if (typemod < -50 && ((tmove(player).power > 1 && attack != Move::Bind && attack != Move::Wrap) || (MoveInfo::isOHKO(attack, gen())))) {
             /* If it's ineffective we just say it */
             notify(All, Effective, target, quint8(0));
             calleffects(player,target,"AttackSomehowFailed");


### PR DESCRIPTION
OHKO should be affected by type immunity in Gen 1. The `power > 1`
check is for Counter/Mirror Coat and Fixed damage (Seismic Toss, etc.)
since those ignore immunities.
