### PR TITLE
RBY/GSC Stat Reduction Errors

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -3771,7 +3771,12 @@ int BattleSituation::getBoostedStat(int player, int stat)
     if (stat == Attack && turnMemory(player).contains("CustomAttackStat")) {
         return turnMemory(player)["CustomAttackStat"].toInt();
     } else if (stat == Attack && turnMemory(player).contains("UnboostedAttackStat")) {
-        return turnMemory(player)["UnboostedAttackStat"].toInt() * getStatBoost(player, Attack);
+        if (gen() > 2) {
+            return turnMemory(player)["UnboostedAttackStat"].toInt() * getStatBoost(player, Attack);
+        } else {
+            //Gen 2 returns same calculated stat as Gen 1
+            return turnMemory(player)["UnboostedAttackStat"].toInt() * (floor(100*getStatBoost(player, Attack))/100);
+        }
     } else{
         int givenStat = stat;
         /* Not sure on the order here... haha. */
@@ -3784,7 +3789,13 @@ int BattleSituation::getBoostedStat(int player, int stat)
             stat = 6 - stat;
             givenStat = 6 - givenStat;
         }
-        return fpoke(player).stats[givenStat] *getStatBoost(player, stat);
+        if (gen() > 2) {
+            return fpoke(player).stats[givenStat] *getStatBoost(player, stat);
+        } else {
+            //Gen 2 returns same calculated stat as Gen 1
+            return fpoke(player).stats[givenStat] * (floor(100*getStatBoost(player, stat))/100);
+        }
+
     }
 }
 

--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -767,7 +767,7 @@ void BattleRBY::changeTempMove(int player, int slot, int move)
 
 int BattleRBY::getBoostedStat(int p, int stat)
 {
-    return poke(p).normalStat(stat) * getStatBoost(p, stat);
+    return poke(p).normalStat(stat) * (floor(100*getStatBoost(p, stat))/100);
 }
 
 bool BattleRBY::loseStatMod(int player, int stat, int malus, int attacker, bool tell)
@@ -785,7 +785,7 @@ bool BattleRBY::loseStatMod(int player, int stat, int malus, int attacker, bool 
         notify(All, StatChange, player, qint8(stat), qint8(-malus), !tell);
         changeStatMod(player, stat, std::max(boost-malus, -6));
     } else {
-        //fixme: can't decrease message
+        notify(All, CappedStat, player, qint8(stat), false);
     }
 
     if (poke(player).status() == Pokemon::Burnt && stat == Attack) {
@@ -806,6 +806,8 @@ bool BattleRBY::gainStatMod(int player, int stat, int bonus, int , bool tell)
     if (boost < 6 && (gen() > 2 || getStat(player, stat) < 999)) {
         notify(All, StatChange, player, qint8(stat), qint8(bonus), !tell);
         changeStatMod(player, stat, std::min(boost+bonus, 6));
+    } else {
+        notify(All, CappedStat, player, qint8(stat), true);
     }
 
     fpoke(player).stats[stat] = getBoostedStat(player, stat);


### PR DESCRIPTION
Example: Converts 2/7 (.2857) to 28/100 (.2800). 
By multiplying by 100 then flooring it turns .2857 into 28.57 into 28.00. Divide by 100 and you've effectively floored to 2 significant digits.

Also adds the CappedStat messages to RBY because I noticed those didn't display.
