### PR TITLE
Toggle to ignore TIs

### DIFF
--- a/src/Teambuilder/challengedialog.cpp
+++ b/src/Teambuilder/challengedialog.cpp
@@ -55,7 +55,14 @@ void ChallengeDialog::setPlayerInfo(const PlayerInfo &info)
     ui->name->setText(info.name);
     ui->avatar->setPixmap(Theme::TrainerSprite(info.avatar));
     ui->avatar->setFixedSize(Theme::TrainerSprite(1).size());
-    ui->description->setText(info.info);
+
+    QSettings s;
+
+    if (s.value("Client/DisplayTIs").toBool()) {
+        ui->description->setText(info.info);
+    } else {
+        ui->description->setText("");
+    }
 
     for (int i = 0; i < ChallengeInfo::numberOfClauses; i++) {
         clauses[i] = new QCheckBox(ChallengeInfo::clause(i));

--- a/src/Teambuilder/client.cpp
+++ b/src/Teambuilder/client.cpp
@@ -1425,6 +1425,11 @@ QMenuBar * Client::createMenuBar(MainEngine *w)
     connect(list_right, SIGNAL(triggered(bool)), SLOT(movePlayerList(bool)));
     list_right->setChecked(globals.value("Client/UserListAtRight").toBool());
 
+    QAction *displayTIs = menuActions->addAction(tr("Display TIs"));
+    displayTIs->setCheckable(true);
+    connect(displayTIs, SIGNAL(triggered(bool)), SLOT(displayTrainerInfo(bool)));
+    displayTIs->setChecked(globals.value("Client/DisplayTIs").toBool());
+
     QAction *oldShortcuts = menuActions->addAction(tr("Use old shortcuts"));
     oldShortcuts->setCheckable(true);
     connect(oldShortcuts, SIGNAL(triggered(bool)), SLOT(useOldShortcuts(bool)));
@@ -2941,4 +2946,8 @@ void Client::showExitWarning()
     } else {
         emit done();
     }
+}
+
+void Client::displayTrainerInfo(bool b) {
+    globals.setValue("Client/DisplayTIs", b);
 }

--- a/src/Teambuilder/client.h
+++ b/src/Teambuilder/client.h
@@ -305,6 +305,7 @@ public slots:
     void toggleChangeNamePM(bool);
     void movePlayerList(bool);
     void useOldShortcuts(bool);
+    void displayTrainerInfo(bool b);
     void ignoreServerVersion(bool);
     void versionDiff(const ProtocolVersion &v, int level);
     void serverNameReceived(const QString &sName);

--- a/src/Teambuilder/mainwindow.cpp
+++ b/src/Teambuilder/mainwindow.cpp
@@ -75,6 +75,7 @@ static void setDefaultValues()
     setDefaultValue(s, "Client/SortPlayersByTier", false);
     setDefaultValue(s, "Client/SortChannelsByName", true);
     setDefaultValue(s, "Client/ShowTimestamps", true);
+    setDefaultValue(s, "Client/DisplayTIs", true);
     setDefaultValue(s, "PlayerEvents/ShowIdle", false);
     setDefaultValue(s, "PlayerEvents/ShowBattle", false);
     setDefaultValue(s, "PlayerEvents/ShowChannel", false);


### PR DESCRIPTION
Also prevents crashing TIs since the TI is never transmitted. TIs are default to "on" but can be turned off by unchecking "Display TIs"
