### PR TITLE
Fix Strong Weather on death

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -2161,7 +2161,8 @@ bool BattleSituation::hasWorkingAbility(int player, int ab)
         // Mold Breaker
         if (heatOfAttack() && player == attacked() && player != attacker() &&
                 (hasWorkingAbility(attacker(), ability(attacker()))
-                 && (ability(attacker()) == Ability::MoldBreaker || ability(attacker()) == Ability::TeraVolt ||  ability(attacker()) == Ability::TurboBlaze))) {
+                 && (ability(attacker()) == Ability::MoldBreaker || ability(attacker()) == Ability::TeraVolt ||  ability(attacker()) == Ability::TurboBlaze))
+                 && ability(attacked()) != Ability::DeltaStream && ability(attacked()) != Ability::PrimordialSea && ability(attacked()) != Ability::DesolateLand) {
             return false;
         }
     }


### PR DESCRIPTION
Start of turn 1
The foe's Zekrom used Bolt Strike!
It's super effective!
Kyogre lost 341 HP! (100% of its health)
Kyogre fainted!
The heavy rain has lifted!
