### PR TITLE
Fix Gyro Ball + Not Breaking it another way

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1805,11 +1805,13 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
                     fpoke(target).add(BasicPokeInfo::HadSubstitute);
                 }
 
-                if (tmove(player).power > 1 && repeatCount() == 0) {
+                /*Gyro Ball needs a special exclusion here to display tooltips correctly because BP is still registered as "1" through the next 2 checks.
+                 * The actual BP isn't calculated until after a crit is determined otherwise the incorrect speed stat and modifiers are used.*/
+                if ((tmove(player).power > 1  || tmove(player).attack == Move::GyroBall) && repeatCount() == 0) {
                     notify(All, Effective, target, quint8(typemod > 0 ? 8 : (typemod < 0 ? 2 : 4)));
                 }
 
-                if (tmove(player).power > 1) {
+                if (tmove(player).power > 1 || tmove(player).attack == Move::GyroBall) {
                     calleffects(player, target, "BeforeHitting");
                     if (turnMemory(player).contains("HitCancelled")) {
                         turnMemory(player).remove("HitCancelled");
@@ -2984,6 +2986,7 @@ void BattleSituation::makePokemonLast(int t)
 int BattleSituation::calculateDamage(int p, int t)
 {
     callaeffects(p,t,"DamageFormulaStart");
+    calleffects(p,t,"DamageFormulaStart");
 
     context &move = turnMemory(p);
     PokeBattle &poke = this->poke(p);

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -3484,13 +3484,13 @@ struct MMBoostSwap : public MM
 struct MMGyroBall : public MM
 {
     MMGyroBall() {
-        functions["BeforeCalculatingDamage"] = &bcd;
+        functions["DamageFormulaStart"] = &bcd;
     }
 
     static void bcd (int s, int t, BS &b) {
         bool speed = turn(b,s)["GyroBall_Arg"].toInt() == 1;
 
-        int bp = 1 + 25 * b.getBoostedStat(speed ? s : t,Speed) / b.getBoostedStat(speed ? t : s,Speed);
+        int bp = 1 + 25 * b.getStat(speed ? s : t,Speed) / b.getStat(speed ? t : s,Speed);
         bp = std::max(2,std::min(bp,150));
 
         tmove(b, s).power = tmove(b, s).power * bp;


### PR DESCRIPTION
fixing another bug related to gyro ball created a new bug. the only way to get both fixed was to change when the formula is run, which is after a crit occurs.
