### PR TITLE
Fixed Leech Seed in RBY

### DIFF
--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -243,7 +243,7 @@ void BattleRBY::personalEndTurn(int player)
 
     if (poke(player).hasStatus(Pokemon::Seeded)) {
         //Leech Seed increases toxic count by 1
-        if (poke(player).status() == Pokemon::Poisoned) {
+        if (poke(player).status() == Pokemon::Poisoned && poke(player).statusCount() != 0) {
             poke(player).statusCount() = std::max(1, poke(player).statusCount() - 1);
         }
         int source = opponent(player);

--- a/src/BattleServer/rbymoves.cpp
+++ b/src/BattleServer/rbymoves.cpp
@@ -588,7 +588,7 @@ struct RBYLeechSeed : public MM
     static void daf(int s, int t, BS &b) {
         if (b.hasType(t, Type::Grass) || b.poke(t).hasStatus(Pokemon::Seeded)) {
             b.failSilently(s);
-            b.sendMoveMessage(72, 0, s, Type::Grass);
+            b.sendMoveMessage(72, 0, t, Type::Grass);
         }
     }
 


### PR DESCRIPTION
Doesn't stack with toxic after switching out, and change fail message to show correct target.
