### PR TITLE
Encore in Gens 5 & 6

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -4058,7 +4058,7 @@ void BattleSituation::storeChoice(const BattleChoice &b)
     BattleBase::storeChoice(b);
 
     /* If the move is encored, a random target is picked. */
-    if (counters(b.slot()).hasCounter(BattleCounterIndex::Encore))
+    if (counters(b.slot()).hasCounter(BattleCounterIndex::Encore) && gen() <= 4)
         choice(b.slot()).choice.attack.attackTarget = b.slot();
 }
 

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1799,7 +1799,9 @@ struct MMEncore : public MM
                     if (b.move(t, i) == mv) {
                         MoveEffect::unsetup(move(b,t), t, b);
                         b.choice(t).setAttackSlot(i);
-                        b.choice(t).setTarget(b.randomValidOpponent(t));
+                        if(b.gen() <= 4) {
+                            b.choice(t).setTarget(b.randomValidOpponent(t));
+                        }
                         MoveEffect::setup(mv, t, s, b);
                         break;
                     }


### PR DESCRIPTION
You can select a target when encored starting with gen 5.
