### PR TITLE
Begone, Spiky Pichu

### DIFF
--- a/bin/db/pokes/6G/released.txt
+++ b/bin/db/pokes/6G/released.txt
@@ -186,7 +186,6 @@
 170:0 Chinchou
 171:0 Lanturn
 172:0 Pichu
-172:1 Spiky Pichu
 173:0 Cleffa
 174:0 Igglybuff
 175:0 Togepi


### PR DESCRIPTION
Can't be transferred to gen 6
