### PR TITLE
Mega Evolutions in Teambuilder

### DIFF
--- a/src/libraries/PokemonInfo/movesetchecker.cpp
+++ b/src/libraries/PokemonInfo/movesetchecker.cpp
@@ -214,7 +214,10 @@ bool MoveSetChecker::isValid(const Pokemon::uniqueId &pokeid, Pokemon::gen gen, 
 
     for (Pokemon::gen g = gen; g >= limit; g = Pokemon::gen(g.num-1, -1)) {
         if (!PokemonInfo::Exists(pokeid, g)) {
-            if (PokemonInfo::HasPreEvo(pokeid.pokenum)) {
+            if(PokemonInfo::IsMegaEvo(pokeid)) {
+                return MoveSetChecker::isValid(PokemonInfo::OriginalForme(pokeid), g, moves, 0, gender, level, maledw,
+                                               invalid_moves, error);
+            } else if (PokemonInfo::HasPreEvo(pokeid.pokenum)) {
                 return MoveSetChecker::isValid(PokemonInfo::PreEvo(pokeid.pokenum), g, moves, 0, gender, level, maledw,
                                                invalid_moves, error);
             }


### PR DESCRIPTION
Fixed mega evolutions being treated as pre evo when checking movesets.
