### PR TITLE
Scale stats if >255 in RBY during damage calculation

### DIFF
--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -719,6 +719,7 @@ int BattleRBY::calculateDamage(int p, int t)
         def = std::min(1024, def*2);
     }
     
+    // In RBY, if either stat is higher than 255, both are quartered during damage calculation
     if (def > 255 || attack > 255) {
     	def = (def/4) % 256;
 	if (def == 0)


### PR DESCRIPTION
I decided to go ahead and send a pull request since this is an extremely minor bug to make a new thread in the forums. 
In RBY, if either stat is higher than 255, both are quartered during damage calculation, in order to fit into a single byte register. Note that "def = 1" doesn't actually occur in the games; in fact, if defense becomes 0 because of this, the game will freeze ("attack = 1 does happen).
Here are the sources: 
http://www.dragonflycave.com/battle.aspx (control + f the word "exceeded")
http://www.smogon.com/forums/threads/obscure-damage-formula-questions.3497953/#post-5161644
My own research can confirm it as well: http://www.smogon.com/forums/threads/past-gens-research-thread.3506992/#post-5878612

I'd also like to point out another thing. I couldn't find information about this anywhere (I just know it from my research), so I decided to wait for feedback:
The Reflect/Light Screen boost (see line 719 in the diff) does not cap at 1024, meaning that the stat can become as high as 999 \* 2 = 1998. This, of course, may lead to a bug when the stats are quartered, a bug I actually made a video about now that I think about it: https://www.youtube.com/watch?v=fVtO_DKxIsI
