### PR TITLE
You can define a tier to not allow Pokemon obtained in earlier games

### DIFF
--- a/src/Server/tier.cpp
+++ b/src/Server/tier.cpp
@@ -12,6 +12,7 @@ unsigned int qHash (const Pokemon::uniqueId &key);
 
 #include <PokemonInfo/pokemoninfo.h>
 #include <PokemonInfo/battlestructs.h>
+#include <PokemonInfo/movesetchecker.h>
 #include "tier.h"
 #include "tiermachine.h"
 #include "security.h"
@@ -404,6 +405,11 @@ bool Tier::isBanned(const PokeBattle &p) const {
         //            return true;
         //            afterloop:;
         //        }
+    }
+    if(minGen > 0) {
+        if(!MoveSetChecker::isValid(p.num(), m_gen, p.move(0).num(), p.move(1).num(), p.move(2).num(), p.move(3).num(), p.ability(), p.gender(), p.level(), false, NULL, NULL, minGen)) {
+            return true;
+        }
     }
 
     if (parent) {
@@ -865,6 +871,7 @@ void Tier::loadFromXml(const QDomElement &elem)
         m_gen.subnum = 0;
     }
 
+    minGen = elem.attribute("minGen", "-1").toInt();
     maxLevel = elem.attribute("maxLevel", "100").toInt();
     numberOfPokemons = elem.attribute("numberOfPokemons", "6").toInt();
     maxRestrictedPokes = elem.attribute("numberOfRestricted", "1").toInt();
@@ -960,6 +967,7 @@ QDomElement & Tier::toXml(QDomElement &dest) const {
     dest.setAttribute("banParent", banParentS);
     dest.setAttribute("gen", m_gen.num);
     dest.setAttribute("subgen", m_gen.subnum);
+    dest.setAttribute("minGen", minGen);
     dest.setAttribute("maxLevel", maxLevel);
     dest.setAttribute("numberOfPokemons", numberOfPokemons);
     dest.setAttribute("numberOfRestricted", maxRestrictedPokes);
@@ -1175,6 +1183,7 @@ Tier::Tier(TierMachine *boss, TierCategory *cat) : boss(boss), node(cat), holder
     banPokes = true;
     parent = nullptr;
     m_gen = Pokemon::gen(GenInfo::GenMax(), GenInfo::NumberOfSubgens(GenInfo::GenMax())-1);
+    minGen = -1;
     maxLevel = 100;
     numberOfPokemons = 6;
     maxRestrictedPokes = 1;
@@ -1241,6 +1250,7 @@ Tier *Tier::dataClone() const
     t.numberOfPokemons = numberOfPokemons;
     t.maxLevel = maxLevel;
     t.m_gen = m_gen;
+    t.minGen = minGen;
     t.banParentS = banParentS;
     t.bannedItems = bannedItems;
     t.bannedMoves = bannedMoves;

--- a/src/Server/tier.h
+++ b/src/Server/tier.h
@@ -184,6 +184,7 @@ private:
 //    QMultiHash<int, BannedPoke> restrictedSets;
     int maxLevel;
     Pokemon::gen m_gen;
+    int minGen;
     QString banParentS;
     Tier *parent;
     QSet<int> bannedItems;

--- a/src/Server/tierwindow.cpp
+++ b/src/Server/tierwindow.cpp
@@ -154,6 +154,7 @@ void TierWindow::openTierEdit(Tier *t)
     }
 
     helper->addConfigHelper(new ConfigCombo<Pokemon::gen>("Generation", t->m_gen, genS,  gens ));
+    helper->addConfigHelper(new ConfigSpin("Minimum generation Pokemon obtained", t->minGen, -1, 6));
     helper->addConfigHelper(new ConfigCheck("Ban pokemon/moves/items (uncheck to restrict the choice to them instead)", t->banPokes));
     helper->addConfigHelper(new ConfigSpin("Max number of pokemon", t->numberOfPokemons, 1, 6));
     helper->addConfigHelper(new ConfigText("Pokemon", pokemons));

--- a/src/libraries/PokemonInfo/movesetchecker.cpp
+++ b/src/libraries/PokemonInfo/movesetchecker.cpp
@@ -122,11 +122,11 @@ void MoveSetChecker::loadGenData(const Pokemon::gen &g)
 }
 
 bool MoveSetChecker::isValid(const Pokemon::uniqueId &pokeid, Pokemon::gen gen, int move1, int move2, int move3, int move4, int ability,
-                             int gender, int level, bool maledw, QSet<int> *invalid_moves, QString *error) {
+                             int gender, int level, bool maledw, QSet<int> *invalid_moves, QString *error, int minGen) {
     QSet<int> moves;
     moves << move1 << move2 << move3 << move4;
 
-    return isValid(pokeid, gen, moves, ability, gender, level, maledw, invalid_moves, error);
+    return isValid(pokeid, gen, moves, ability, gender, level, maledw, invalid_moves, error, minGen);
 }
 
 static QString getCombinationS(const QSet<int> &invalid_moves) {
@@ -176,7 +176,7 @@ static QString getCombinationS(const QSet<int> &invalid_moves) {
  * 4th gen evos with 3rd gen moves. But there should be a comment everytime for
  * those exceptions in the code below. */
 bool MoveSetChecker::isValid(const Pokemon::uniqueId &pokeid, Pokemon::gen gen, const QSet<int> &moves2, int ability, int gender,
-                             int level, bool maledw, QSet<int> *invalid_moves, QString *error)
+                             int level, bool maledw, QSet<int> *invalid_moves, QString *error, int minGen)
 {
     if (gen == Gen::StadiumWithTradebacks) {
         foreach(int move, moves2) {
@@ -208,9 +208,9 @@ bool MoveSetChecker::isValid(const Pokemon::uniqueId &pokeid, Pokemon::gen gen, 
     int limit;
 
     if (gen >= 3)
-        limit = 3;
+        limit = std::max(3, minGen);
     else
-        limit = 1;
+        limit = std::max(1, minGen);
 
     for (Pokemon::gen g = gen; g >= limit; g = Pokemon::gen(g.num-1, -1)) {
         if (!PokemonInfo::Exists(pokeid, g)) {

--- a/src/libraries/PokemonInfo/movesetchecker.h
+++ b/src/libraries/PokemonInfo/movesetchecker.h
@@ -10,10 +10,10 @@ public:
     static void init(const QString &dir="db/pokes/", bool enforceMinLevels = true);
     static void loadCombinations(const QString &file, Pokemon::gen gen, QHash<Pokemon::gen, QHash<Pokemon::uniqueId, QList<QSet<int> > > > &set);
     static bool isValid(const Pokemon::uniqueId &pokeid, Pokemon::gen gen, const QSet<int> &moves, int ability = 0, int gender = 0,
-                        int level=100, bool maledw = false, QSet<int> *invalid_moves=NULL, QString *error = NULL);
+                        int level=100, bool maledw = false, QSet<int> *invalid_moves=NULL, QString *error = NULL, int minGen = -1);
     static bool isValid(const Pokemon::uniqueId &pokeid, Pokemon::gen gen, int move1,int move2, int move3, int move4, int ability = 0, int gender = 0,
                         int level = 100, bool maledw = false,
-                        QSet<int> *invalid_moves=NULL, QString *error = NULL);
+                        QSet<int> *invalid_moves=NULL, QString *error = NULL, int minGen = -1);
     static bool isAnEggMoveCombination(const Pokemon::uniqueId &pokeid, Pokemon::gen gen, QSet<int> moves);
     static QList<QSet<int> > combinationsFor(Pokemon::uniqueId pokenum, Pokemon::gen gen);
     static QHash<Pokemon::uniqueId, QList<QSet<int> > > eventCombinationsOf(Pokemon::gen gen);


### PR DESCRIPTION
You can set the minGen in VGC 2014 to "6" to enforce pre-pokebank. Only thing this matters for right now, but VGC '15 will probably have the same rule.
