### PR TITLE
More RBY stuff

### DIFF
--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -714,9 +714,19 @@ int BattleRBY::calculateDamage(int p, int t)
         def = crit ? this->poke(t).normalStat(SpAttack) : getStat(t, SpAttack);
     }
 
+    //burn
+    if (!crit) {
+        //Burn does not halve the attack stat during damage calculation of Critical hits in RBY
+        attack = attack / ((poke.status() == Pokemon::Burnt && cat == Move::Physical) ? 2 : 1);
+        //Minimum attack is set to 1
+        if (attack == 0) {
+            attack = 1;	
+        }
+
     /* Light screen / Reflect */
+    //In RBY, Reflect / Light Screen boost doesn't cap the stat at 999 or 1023
     if ( !crit && pokeMemory(t).value("Barrier" + QString::number(cat) + "Count").toInt() > 0) {
-        def = std::min(1024, def*2);
+        def/=2);
     }
     
     // In RBY, if either stat is higher than 255, both are quartered during damage calculation
@@ -747,12 +757,6 @@ int BattleRBY::calculateDamage(int p, int t)
     power = std::min(power, 65535);
     int damage = ((std::min(((level * ch * 2 / 5) + 2) * power, 65535) * attack / def) / 50) + 2;
 
-    //Guts, burn
-    if (!crit){
-        //Burn does not halve the damage of Critical hits in RBY
-        damage = damage / ((poke.status() == Pokemon::Burnt && cat == Move::Physical) ? 2 : 1);
-    }
-
     damage = (damage * stab/2) ;
     while (typemod > 0) {
         damage *= 2;
@@ -762,7 +766,12 @@ int BattleRBY::calculateDamage(int p, int t)
         damage /= 2;
         typemod++;
     }
-    damage = (damage * randnum) / 255;
+    
+    // In RBY, minimum damage after randnum is applied is 1, 
+    // unless it became 0 during typemod calculations.
+    if (damage != 1) {
+    	damage = (damage * randnum) / 255;
+    }
 
     return damage;
 }


### PR DESCRIPTION
See https://github.com/po-devs/pokemon-online/pull/1325

First off, I decided to go ahead again and create a pull request without making an actual bug report in the forums or anything. I'd you'd rather I stop doing this stuff directly myself just tell me (or maybe there are certain things you don't want to implement at all for some reason). I thought this way it would be faster for everyone, and I just want to contribute!
1. Line ~727: After a Reflect or Light Screen boost is applied, the stat does not cap at any value (therefore max stat is 1998). This does lead to a bug in Pokemon R/B/Y where, if stats over 1024 have to be scaled, they'd become unusually low. Not only this, but defense stat values between 1024 and 1027 (512-513 before R/LS boost) freeze the game due to dividing by 0. This wouldn't happen in the simulator because the "scaling by 4" function I submitted three days ago (has already been merged) includes a "if def=0 -> def=1" line not emulated in the real Pokemon R/B/Y games.
   Sources (my research): http://www.smogon.com/forums/threads/past-gens-research-thread.3506992/
   Dissasembly of Pokemon Red: https://github.com/iimarckus/pokered/blob/master/engine/battle/core.asm#L4180
   Possibly an useful video (shows the glitch): https://www.youtube.com/watch?v=fVtO_DKxIsI
2. Line ~770: This is very irrelevant but the random factor (217-255) isn't applied if damage is 0 or 1.
   Sources: my research (see above)
   Dissasembly of Pokemon Red: https://github.com/iimarckus/pokered/blob/master/engine/battle/core.asm#L5548 (cp 2 + ret c means return if current damage is <2)
3. Line ~717 and ~750: Burn does not halve damage, but the current attack stat, and happens before scaling and along with Reflect/LS boosts and stat mods. Actually, the game keeps two version of each stat: the original and a modified one with mods/burn/reflect/LS applied (just a FYI)
   Sources: my research (see above)
   Dissasembly of Pokemon Red:
   https://github.com/iimarckus/pokered/blob/master/engine/battle/core.asm#L6443
