### PR TITLE
Outrage disable mechanics

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1522,7 +1522,6 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
     if (turnMemory(player).value("ImpossibleToMove").toBool()) {
         goto trueend;
     }
-
     if (!specialOccurence) {
         if (PP(player, move) <= 0) {
             notify(All, UseAttack, player, qint16(attack), !(tellPlayers && !turnMemory(player).contains("TellPlayers")));
@@ -1541,6 +1540,11 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
             So that's why attack is tested against 0. */
         pokeMemory(player)["AnyLastMoveUsed"] = attack;
         battleMemory()["AnyLastMoveUsed"] = attack;
+        if (pokeMemory(player).contains("OutrageMove")) {
+            /* Have to set last move for disable to work on 2nd or 3rd turn*/
+            pokeMemory(player)["LastMoveUsed"] = attack;
+            pokeMemory(player)["LastMoveUsedTurn"] = turn();
+        }
     }
 
     //For metronome calling fly / sky attack / ...

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -5424,14 +5424,18 @@ struct MMOutrage : public MM
     }
 
     static void aas(int s, int, BS &b) {
-        if (poke(b,s).contains("OutrageUntil") && b.turn() == poke(b,s)["OutrageUntil"].toInt()) {
+        bool disabled = poke(b,s).contains("DisabledMove") && poke(b,s)["OutrageMove"] == poke(b,s)["DisabledMove"].toInt();
+        bool lastTurn = poke(b,s).contains("OutrageUntil") && b.turn() == poke(b,s)["OutrageUntil"].toInt();
+        if (lastTurn || disabled) {
+            if(!disabled || (b.gen() >= 5 && lastTurn)) {
+                b.sendMoveMessage(93,0,s,type(b,s));
+                b.inflictConfused(s, s, b.gen() >= 2);
+            }
             removeFunction(poke(b,s), "TurnSettings", "Outrage");
             b.removeEndTurnEffect(BS::PokeEffect, s, "Outrage");
             poke(b,s).remove("OutrageUntil");
             poke(b,s).remove("OutrageMove");
             poke(b,s).remove("LastOutrage");
-            b.sendMoveMessage(93,0,s,type(b,s));
-            b.inflictConfused(s, s, b.gen() >= 2);
         }
     }
 


### PR DESCRIPTION
In gens 5 and 6, Outrage confusion will occur if the move is disabled on what would have been the last turn of Outrage. Outrage doesn't inflict confusion when disabled in other gens.
