### PR TITLE
Validate movesets upon ability change

### DIFF
--- a/src/Teambuilder/Teambuilder/pokelevelsettings.cpp
+++ b/src/Teambuilder/Teambuilder/pokelevelsettings.cpp
@@ -1,3 +1,5 @@
+#include <QMessageBox>
+
 #include <PokemonInfo/pokemonstructs.h>
 #include <PokemonInfo/pokemoninfo.h>
 #include "Teambuilder/pokelevelsettings.h"
@@ -84,12 +86,26 @@ void PokeLevelSettings::changeAbility()
         return;
     }
 
+    int abilityToSet;
     if (m_abilities[1]->isChecked()) {
-        poke().ability() = poke().abilities().ab(1);
+        abilityToSet = poke().abilities().ab(1);
     } else if (m_abilities[2]->isChecked()) {
-        poke().ability() = poke().abilities().ab(2);
+        abilityToSet = poke().abilities().ab(2);
     } else {
-        poke().ability() = poke().abilities().ab(0);
+        abilityToSet = poke().abilities().ab(0);
+    }
+
+    try {
+        poke().setAbility(abilityToSet);
+    } catch (const QString &s) {
+        QMessageBox::information(NULL, tr("Invalid moveset"), s);
+        for(int i = 0; i < 3; i++) {
+            if(poke().ability() == poke().abilities().ab(i)) {
+                m_abilities[i]->setChecked(true);
+            } else {
+                m_abilities[i]->setChecked(false);
+            }
+        }
     }
 }
 

--- a/src/libraries/PokemonInfo/pokemonstructs.cpp
+++ b/src/libraries/PokemonInfo/pokemonstructs.cpp
@@ -186,6 +186,17 @@ void PokePersonal::setMove(int moveNum, int moveSlot, bool check) throw(QString)
     }
 }
 
+void PokePersonal::setAbility(int abilityNum) throw(QString)
+{
+    QSet<int> invalid_moves;
+    QString error;
+    if (!MoveSetChecker::isValid(num(), gen(), m_moves[0],m_moves[1],m_moves[2],m_moves[3],abilityNum,gender(),level(),false,&invalid_moves, &error)) {
+        throw error;
+    } else {
+        ability() = abilityNum;
+    }
+}
+
 void PokePersonal::runCheck()
 {
     if (!PokemonInfo::Exists(num(), gen())) {

--- a/src/libraries/PokemonInfo/pokemonstructs.h
+++ b/src/libraries/PokemonInfo/pokemonstructs.h
@@ -125,6 +125,8 @@ public:
 
     bool hasMove(int moveNum);
 
+    void setAbility(int abilityNum) throw (QString);
+
     quint8 DV(int stat) const;
     void setDV(int stat, quint8 DV);
     void controlHPDV();


### PR DESCRIPTION
If a user has already set some moves then changes the ability to one which can not go with those moves, notifies the user and changes the ability back.
