### PR TITLE
Battle factory doesn't change the players teams

### DIFF
--- a/src/Server/battlecommunicator.cpp
+++ b/src/Server/battlecommunicator.cpp
@@ -46,13 +46,13 @@ bool BattleCommunicator::valid() const
     return relay && relay->isConnected();
 }
 
-void BattleCommunicator::startBattle(Player *p1, Player *p2, const ChallengeInfo &c, int id, int team1, int team2)
+void BattleCommunicator::startBattle(Player *p1, Player *p2, const ChallengeInfo &c, int id, TeamBattle team1, TeamBattle team2)
 {
     if (!valid()) {
         qFatal("Starting a battle when no valid connections");
     }
 
-    QString tier = p1->team(team1).tier == p2->team(team2).tier ? p1->team(team1).tier : QString("Mixed %1").arg(GenInfo::Version(p1->team(team1).gen));
+    QString tier = team1.tier == team2.tier ? team1.tier : QString("Mixed %1").arg(GenInfo::Version(team1.gen));
 
     mybattles.insert(id, new FullBattleConfiguration(id, p1->id(), p2->id(), tier, c));
     mybattles[id]->name[0] = p1->name();
@@ -61,19 +61,19 @@ void BattleCommunicator::startBattle(Player *p1, Player *p2, const ChallengeInfo
     if (TierMachine::obj()->exists(tier)) {
         Tier & t = TierMachine::obj()->tier(tier);
 
-        BattlePlayer pb1(p1->name(), p1->id(), p1->rating(p1->team(team1).tier), p1->avatar(), p1->winningMessage(), p1->losingMessage(),
-                         p1->tieMessage(), t.getMaxLevel(), t.restricted(p1->team(team1)), t.maxRestrictedPokes, t.numberOfPokemons);
-        BattlePlayer pb2(p2->name(), p2->id(), p2->rating(p2->team(team2).tier), p2->avatar(), p2->winningMessage(), p2->losingMessage(),
-                         p2->tieMessage(), t.getMaxLevel(), t.restricted(p2->team(team2)), t.maxRestrictedPokes, t.numberOfPokemons);
+        BattlePlayer pb1(p1->name(), p1->id(), p1->rating(team1.tier), p1->avatar(), p1->winningMessage(), p1->losingMessage(),
+                         p1->tieMessage(), t.getMaxLevel(), t.restricted(team1), t.maxRestrictedPokes, t.numberOfPokemons);
+        BattlePlayer pb2(p2->name(), p2->id(), p2->rating(team2.tier), p2->avatar(), p2->winningMessage(), p2->losingMessage(),
+                         p2->tieMessage(), t.getMaxLevel(), t.restricted(team2), t.maxRestrictedPokes, t.numberOfPokemons);
 
-        relay->startBattle(id, pb1, pb2, c, p1->team(team1), p2->team(team2));
+        relay->startBattle(id, pb1, pb2, c, team1, team2);
     } else {
-        BattlePlayer pb1(p1->name(), p1->id(), p1->rating(p1->team(team1).tier), p1->avatar(), p1->winningMessage(), p1->losingMessage(),
+        BattlePlayer pb1(p1->name(), p1->id(), p1->rating(team1.tier), p1->avatar(), p1->winningMessage(), p1->losingMessage(),
                          p1->tieMessage());
-        BattlePlayer pb2(p2->name(), p2->id(), p2->rating(p2->team(team2).tier), p2->avatar(), p2->winningMessage(), p2->losingMessage(),
+        BattlePlayer pb2(p2->name(), p2->id(), p2->rating(team2.tier), p2->avatar(), p2->winningMessage(), p2->losingMessage(),
                          p2->tieMessage());
 
-        relay->startBattle(id, pb1, pb2, c, p1->team(team1), p2->team(team2));
+        relay->startBattle(id, pb1, pb2, c, team1, team2);
     }
 
     p1->addBattle(id);

--- a/src/Server/battlecommunicator.cpp
+++ b/src/Server/battlecommunicator.cpp
@@ -46,7 +46,7 @@ bool BattleCommunicator::valid() const
     return relay && relay->isConnected();
 }
 
-void BattleCommunicator::startBattle(Player *p1, Player *p2, const ChallengeInfo &c, int id, TeamBattle team1, TeamBattle team2)
+void BattleCommunicator::startBattle(Player *p1, Player *p2, const ChallengeInfo &c, int id, TeamBattle &team1, TeamBattle &team2)
 {
     if (!valid()) {
         qFatal("Starting a battle when no valid connections");

--- a/src/Server/battlecommunicator.h
+++ b/src/Server/battlecommunicator.h
@@ -29,7 +29,7 @@ public:
     /* Can we have battles? */
     bool valid() const;
 
-    void startBattle(Player *p1, Player *p2, const ChallengeInfo &c, int id, TeamBattle team1, TeamBattle team2);
+    void startBattle(Player *p1, Player *p2, const ChallengeInfo &c, int id, TeamBattle &team1, TeamBattle &team2);
     void loadPlugin(const QString &path);
     void unloadPlugin(const QString &name);
 

--- a/src/Server/battlecommunicator.h
+++ b/src/Server/battlecommunicator.h
@@ -29,7 +29,7 @@ public:
     /* Can we have battles? */
     bool valid() const;
 
-    void startBattle(Player *p1, Player *p2, const ChallengeInfo &c, int id, int team1, int team2);
+    void startBattle(Player *p1, Player *p2, const ChallengeInfo &c, int id, TeamBattle team1, TeamBattle team2);
     void loadPlugin(const QString &path);
     void unloadPlugin(const QString &name);
 

--- a/src/Server/scriptengine.h
+++ b/src/Server/scriptengine.h
@@ -149,7 +149,7 @@ public:
     void afterFindBattle(int src);
 
     void battleConnectionLost();
-    
+
     /* Imports a module with a given name */
     Q_INVOKABLE QScriptValue import(const QString &fileName);
     /* Functions called in scripts */
@@ -197,12 +197,12 @@ public:
     Q_INVOKABLE void changeAway(int id, bool away);
 
     Q_INVOKABLE void changeRating(const QString& name, const QString& tier, int newRating);
-    Q_INVOKABLE void changePokeLevel(int id, unsigned int team, int slot, int level);
-    Q_INVOKABLE void changePokeNum(int id, unsigned int team, int slot, int num);
-    Q_INVOKABLE void changePokeItem(int id, unsigned int team, int slot, int item);
-    Q_INVOKABLE void changePokeMove(int id, unsigned int team, int pokeslot, int moveslot, int move);
-    Q_INVOKABLE void changePokeGender(int id, unsigned int team, int pokeslot, int gender);
-    Q_INVOKABLE void changePokeName(int id, unsigned int team, int pokeslot, const QString &name);
+    Q_INVOKABLE void changePokeLevel(int id, quint32 teamLo, int slot, int level, quint32 teamHi = 0);
+    Q_INVOKABLE void changePokeNum(int id, quint32 teamLo, int slot, int num, quint32 teamHi = 0);
+    Q_INVOKABLE void changePokeItem(int id, quint32 teamLo, int slot, int item, quint32 teamHi = 0);
+    Q_INVOKABLE void changePokeMove(int id, quint32 teamLo, int pokeslot, int moveslot, int move, quint32 teamHi = 0);
+    Q_INVOKABLE void changePokeGender(int id, quint32 teamLo, int pokeslot, int gender, quint32 teamHi = 0);
+    Q_INVOKABLE void changePokeName(int id, quint32 teamLo, int pokeslot, const QString &name, quint32 teamHi = 0);
     Q_INVOKABLE void changePokeHp(int id, int team, int slot, int hp);
     Q_INVOKABLE void changePokeStatus(int id, int team, int slot, int status);
     Q_INVOKABLE void changePokePP(int id, int team, int slot, int moveslot, int PP);
@@ -263,7 +263,7 @@ public:
     Q_INVOKABLE QScriptValue battling(int id);
     Q_INVOKABLE QScriptValue battlingIds();
     Q_INVOKABLE QScriptValue away(int id);
-    Q_INVOKABLE QScriptValue ip(int id); 
+    Q_INVOKABLE QScriptValue ip(int id);
     Q_INVOKABLE QScriptValue proxyIp(int id);
     Q_INVOKABLE void hostName(const QString &ip, const QScriptValue &function);
     Q_INVOKABLE QScriptValue gen(int id, int team);
@@ -283,7 +283,7 @@ public:
     Q_INVOKABLE QScriptValue dbTempBanTime(const QString &name);
     Q_INVOKABLE int dbExpiration();
     Q_INVOKABLE bool dbRegistered(const QString &name);
-    Q_INVOKABLE QScriptValue tier(int id, unsigned int team);
+    Q_INVOKABLE QScriptValue tier(int id, quint32 teamLo, quint32 teamHi = 0);
     Q_INVOKABLE bool hasTier(int id, const QString &tier);
     Q_INVOKABLE QScriptValue ranking(int id, int team);
     Q_INVOKABLE QScriptValue ratedBattles(int id, int team);
@@ -345,32 +345,32 @@ public:
     Q_INVOKABLE QScriptValue genderNum(QString genderName);
     Q_INVOKABLE QString gender(int genderNum);
 
-    Q_INVOKABLE QScriptValue teamPokeLevel(int id, unsigned int team, int slot);
+    Q_INVOKABLE QScriptValue teamPokeLevel(int id, quint32 teamLo, int slot, quint32 teamHi = 0);
     Q_INVOKABLE QScriptValue teamPokeStat(int id, int team, int slot, int stat);
     Q_INVOKABLE QScriptValue teamPokeHp(int id, int team, int slot); //Stat would return total hp
     Q_INVOKABLE QScriptValue teamPokeStatus(int id, int team, int slot);
     Q_INVOKABLE QScriptValue teamPokePP(int id, int team, int slot, int moveslot);
-    Q_INVOKABLE QScriptValue teamPoke(int id, unsigned int team, int index);
+    Q_INVOKABLE QScriptValue teamPoke(int id, quint32 teamLo, int index, quint32 teamHi = 0);
     Q_INVOKABLE QScriptValue teamPokeName(int id, int team, int pokemonnum);
     Q_INVOKABLE bool hasTeamPoke(int id, int team, int pokemonnum);
     Q_INVOKABLE QScriptValue indexOfTeamPoke(int id, int team, int pokenum);
     Q_INVOKABLE bool hasDreamWorldAbility(int id, int team, int slot, int gen = 5);
     Q_INVOKABLE bool compatibleAsDreamWorldEvent(int id, int team, int slot);
 
-    Q_INVOKABLE QScriptValue teamPokeMove(int id, unsigned int team, int pokeindex, int moveindex);
-    Q_INVOKABLE bool hasTeamPokeMove(int id, unsigned int team, int pokeindex, int movenum);
+    Q_INVOKABLE QScriptValue teamPokeMove(int id, quint32 teamLo, int pokeindex, int moveindex, quint32 teamHi = 0);
+    Q_INVOKABLE bool hasTeamPokeMove(int id, quint32 teamLo, int pokeindex, int movenum, quint32 teamHi = 0);
     Q_INVOKABLE QScriptValue indexOfTeamPokeMove(int id, int team, int pokeindex, int movenum);
     Q_INVOKABLE bool hasTeamMove(int id, int team, int movenum);
 
-    Q_INVOKABLE QScriptValue teamPokeItem(int id, unsigned int team, int pokeindex);
+    Q_INVOKABLE QScriptValue teamPokeItem(int id, quint32 teamLo, int pokeindex, quint32 teamHi = 0);
     Q_INVOKABLE bool hasTeamItem(int id, int team, int itemNum);
 
     Q_INVOKABLE QScriptValue teamPokeHappiness(int id, int team, int slot);
-    Q_INVOKABLE QScriptValue teamPokeNature(int id, unsigned int team, int slot);
-    Q_INVOKABLE QScriptValue teamPokeEV(int id, unsigned int team, int slot, int stat);
-    Q_INVOKABLE QScriptValue teamPokeDV(int id, unsigned int team, int slot, int stat);
-    Q_INVOKABLE void changeTeamPokeDV(int id, unsigned int team, int slot, int stat, int newValue);
-    Q_INVOKABLE void changeTeamPokeEV(int id, unsigned int team, int slot, int stat, int newValue);
+    Q_INVOKABLE QScriptValue teamPokeNature(int id, quint32 teamLo, int slot, quint32 teamHi = 0);
+    Q_INVOKABLE QScriptValue teamPokeEV(int id, quint32 teamLo, int slot, int stat, quint32 teamHi = 0);
+    Q_INVOKABLE QScriptValue teamPokeDV(int id, quint32 teamLo, int slot, int stat, quint32 teamHi = 0);
+    Q_INVOKABLE void changeTeamPokeDV(int id, quint32 teamLo, int slot, int stat, int newValue, quint32 teamHi = 0);
+    Q_INVOKABLE void changeTeamPokeEV(int id, quint32 teamLo, int slot, int stat, int newValue, quint32 teamHi = 0);
 
     Q_INVOKABLE int numPlayers();
     Q_INVOKABLE int playersInMemory();
@@ -395,7 +395,7 @@ public:
 
     /* Returns an array of "male", "female", "neutral" with percentages associated */
     Q_INVOKABLE QScriptValue pokeGenders(int poke);
-   
+
     Q_INVOKABLE QScriptValue banList();
     Q_INVOKABLE void ban(QString name);
     Q_INVOKABLE void tempBan(QString name, int time);
@@ -415,13 +415,13 @@ public:
 
     Q_INVOKABLE void swapPokemons(int pid, int teamSlot, int slot1, int slot2);
 
-    Q_INVOKABLE int teamPokeAbility(int id, unsigned int team, int slot);
-    Q_INVOKABLE void changePokeAbility(int id, unsigned int team, int slot, int ability);
+    Q_INVOKABLE int teamPokeAbility(int id, quint32 teamLo, int slot, quint32 teamHi = 0);
+    Q_INVOKABLE void changePokeAbility(int id, quint32 teamLo, int slot, int ability, quint32 teamHi = 0);
     Q_INVOKABLE QScriptValue pokeAbility(int poke, int slot, int gen = GenInfo::GenMax());
-    Q_INVOKABLE void changePokeHappiness(int id, unsigned int team, int slot, int value);
-    Q_INVOKABLE void changePokeShine(int id, unsigned int team, int slot, bool value);
+    Q_INVOKABLE void changePokeHappiness(int id, quint32 teamLo, int slot, int value, quint32 teamHi = 0);
+    Q_INVOKABLE void changePokeShine(int id, quint32 teamLo, int slot, bool value, quint32 teamHi = 0);
     Q_INVOKABLE QScriptValue teamPokeShine(int id, int team, int slot);
-    Q_INVOKABLE void changePokeNature(int id, unsigned int team, int pokeslot, int nature);
+    Q_INVOKABLE void changePokeNature(int id, quint32 teamLo, int pokeslot, int nature, quint32 teamHi = 0);
     Q_INVOKABLE QScriptValue teamPokeGender(int id, int team, int slot);
 
     Q_INVOKABLE QScriptValue teamPokeNick(int id, int team, int pokeslot);
@@ -442,7 +442,7 @@ public:
 
     /* Internal use only */
     Q_INVOKABLE void sendNetworkCommand(int id, int command);
-    
+
     Q_INVOKABLE QString sha1(const QString &text);
     Q_INVOKABLE QString md4(const QString &text);
     Q_INVOKABLE QString md5(const QString &text);
@@ -564,7 +564,7 @@ private slots:
     void synchronousWebCall_replyFinished(QNetworkReply* reply);
 #endif
     void hostInfo_Ready(const QHostInfo &myInfo);
-    
+
 private:
     bool strict;
     bool wfatal;

--- a/src/Server/scriptengine.h
+++ b/src/Server/scriptengine.h
@@ -12,8 +12,11 @@
 #include <QNetworkReply>
 #include <QHostInfo>
 
+#include <PokemonInfo/pokemoninfo.h>
 #include <PokemonInfo/geninfo.h>
 #include <Utilities/functions.h>
+
+#include "battlecommunicator.h"
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -122,7 +125,7 @@ public:
     bool beforeBattleMatchup(int src, int dest, const ChallengeInfo &desc);
     void afterBattleMatchup(int src, int dest, const ChallengeInfo &desc);
 
-    void beforeBattleStarted(int src, int dest, const ChallengeInfo &desc, int battleid, int team1, int team2);
+    void beforeBattleStarted(int src, int dest, const ChallengeInfo &desc, int battleid, TeamBattle &team1, TeamBattle &team2);
     void afterBattleStarted(int winner, int loser, const ChallengeInfo &desc, int battleid, int team1, int team2);
 
     void beforeBattleEnded(int winner, int loser, int desc, int battleid);
@@ -194,12 +197,12 @@ public:
     Q_INVOKABLE void changeAway(int id, bool away);
 
     Q_INVOKABLE void changeRating(const QString& name, const QString& tier, int newRating);
-    Q_INVOKABLE void changePokeLevel(int id, int team, int slot, int level);
-    Q_INVOKABLE void changePokeNum(int id, int team, int slot, int num);
-    Q_INVOKABLE void changePokeItem(int id, int team, int slot, int item);
-    Q_INVOKABLE void changePokeMove(int id, int team, int pokeslot, int moveslot, int move);
-    Q_INVOKABLE void changePokeGender(int id, int team, int pokeslot, int gender);
-    Q_INVOKABLE void changePokeName(int id, int team, int pokeslot, const QString &name);
+    Q_INVOKABLE void changePokeLevel(int id, unsigned int team, int slot, int level);
+    Q_INVOKABLE void changePokeNum(int id, unsigned int team, int slot, int num);
+    Q_INVOKABLE void changePokeItem(int id, unsigned int team, int slot, int item);
+    Q_INVOKABLE void changePokeMove(int id, unsigned int team, int pokeslot, int moveslot, int move);
+    Q_INVOKABLE void changePokeGender(int id, unsigned int team, int pokeslot, int gender);
+    Q_INVOKABLE void changePokeName(int id, unsigned int team, int pokeslot, const QString &name);
     Q_INVOKABLE void changePokeHp(int id, int team, int slot, int hp);
     Q_INVOKABLE void changePokeStatus(int id, int team, int slot, int status);
     Q_INVOKABLE void changePokePP(int id, int team, int slot, int moveslot, int PP);
@@ -280,7 +283,7 @@ public:
     Q_INVOKABLE QScriptValue dbTempBanTime(const QString &name);
     Q_INVOKABLE int dbExpiration();
     Q_INVOKABLE bool dbRegistered(const QString &name);
-    Q_INVOKABLE QScriptValue tier(int id, int team);
+    Q_INVOKABLE QScriptValue tier(int id, unsigned int team);
     Q_INVOKABLE bool hasTier(int id, const QString &tier);
     Q_INVOKABLE QScriptValue ranking(int id, int team);
     Q_INVOKABLE QScriptValue ratedBattles(int id, int team);
@@ -342,32 +345,32 @@ public:
     Q_INVOKABLE QScriptValue genderNum(QString genderName);
     Q_INVOKABLE QString gender(int genderNum);
 
-    Q_INVOKABLE QScriptValue teamPokeLevel(int id, int team, int slot);
+    Q_INVOKABLE QScriptValue teamPokeLevel(int id, unsigned int team, int slot);
     Q_INVOKABLE QScriptValue teamPokeStat(int id, int team, int slot, int stat);
     Q_INVOKABLE QScriptValue teamPokeHp(int id, int team, int slot); //Stat would return total hp
     Q_INVOKABLE QScriptValue teamPokeStatus(int id, int team, int slot);
     Q_INVOKABLE QScriptValue teamPokePP(int id, int team, int slot, int moveslot);
-    Q_INVOKABLE QScriptValue teamPoke(int id, int team, int index);
+    Q_INVOKABLE QScriptValue teamPoke(int id, unsigned int team, int index);
     Q_INVOKABLE QScriptValue teamPokeName(int id, int team, int pokemonnum);
     Q_INVOKABLE bool hasTeamPoke(int id, int team, int pokemonnum);
     Q_INVOKABLE QScriptValue indexOfTeamPoke(int id, int team, int pokenum);
     Q_INVOKABLE bool hasDreamWorldAbility(int id, int team, int slot, int gen = 5);
     Q_INVOKABLE bool compatibleAsDreamWorldEvent(int id, int team, int slot);
 
-    Q_INVOKABLE QScriptValue teamPokeMove(int id, int team, int pokeindex, int moveindex);
-    Q_INVOKABLE bool hasTeamPokeMove(int id, int team, int pokeindex, int movenum);
+    Q_INVOKABLE QScriptValue teamPokeMove(int id, unsigned int team, int pokeindex, int moveindex);
+    Q_INVOKABLE bool hasTeamPokeMove(int id, unsigned int team, int pokeindex, int movenum);
     Q_INVOKABLE QScriptValue indexOfTeamPokeMove(int id, int team, int pokeindex, int movenum);
     Q_INVOKABLE bool hasTeamMove(int id, int team, int movenum);
 
-    Q_INVOKABLE QScriptValue teamPokeItem(int id, int team, int pokeindex);
+    Q_INVOKABLE QScriptValue teamPokeItem(int id, unsigned int team, int pokeindex);
     Q_INVOKABLE bool hasTeamItem(int id, int team, int itemNum);
 
     Q_INVOKABLE QScriptValue teamPokeHappiness(int id, int team, int slot);
-    Q_INVOKABLE QScriptValue teamPokeNature(int id, int team, int slot);
-    Q_INVOKABLE QScriptValue teamPokeEV(int id, int team, int slot, int stat);
-    Q_INVOKABLE QScriptValue teamPokeDV(int id, int team, int slot, int stat);
-    Q_INVOKABLE void changeTeamPokeDV(int id, int team, int slot, int stat, int newValue);
-    Q_INVOKABLE void changeTeamPokeEV(int id, int team, int slot, int stat, int newValue);
+    Q_INVOKABLE QScriptValue teamPokeNature(int id, unsigned int team, int slot);
+    Q_INVOKABLE QScriptValue teamPokeEV(int id, unsigned int team, int slot, int stat);
+    Q_INVOKABLE QScriptValue teamPokeDV(int id, unsigned int team, int slot, int stat);
+    Q_INVOKABLE void changeTeamPokeDV(int id, unsigned int team, int slot, int stat, int newValue);
+    Q_INVOKABLE void changeTeamPokeEV(int id, unsigned int team, int slot, int stat, int newValue);
 
     Q_INVOKABLE int numPlayers();
     Q_INVOKABLE int playersInMemory();
@@ -412,13 +415,13 @@ public:
 
     Q_INVOKABLE void swapPokemons(int pid, int teamSlot, int slot1, int slot2);
 
-    Q_INVOKABLE int teamPokeAbility(int id, int team, int slot);
-    Q_INVOKABLE void changePokeAbility(int id, int team, int slot, int ability);
+    Q_INVOKABLE int teamPokeAbility(int id, unsigned int team, int slot);
+    Q_INVOKABLE void changePokeAbility(int id, unsigned int team, int slot, int ability);
     Q_INVOKABLE QScriptValue pokeAbility(int poke, int slot, int gen = GenInfo::GenMax());
-    Q_INVOKABLE void changePokeHappiness(int id, int team, int slot, int value);
-    Q_INVOKABLE void changePokeShine(int id, int team, int slot, bool value);
+    Q_INVOKABLE void changePokeHappiness(int id, unsigned int team, int slot, int value);
+    Q_INVOKABLE void changePokeShine(int id, unsigned int team, int slot, bool value);
     Q_INVOKABLE QScriptValue teamPokeShine(int id, int team, int slot);
-    Q_INVOKABLE void changePokeNature(int id, int team, int pokeslot, int nature);
+    Q_INVOKABLE void changePokeNature(int id, unsigned int team, int pokeslot, int nature);
     Q_INVOKABLE QScriptValue teamPokeGender(int id, int team, int slot);
 
     Q_INVOKABLE QScriptValue teamPokeNick(int id, int team, int pokeslot);

--- a/src/Server/server.cpp
+++ b/src/Server/server.cpp
@@ -1484,8 +1484,6 @@ void Server::startBattle(int id1, int id2, const ChallengeInfo &c, int team1, in
 
     int id = freebattleid();
 
-    myengine->beforeBattleStarted(id1,id2,c,id,team1,team2);
-
     if (!playerExist(id1) || !playerExist(id2))
         return;
 
@@ -1509,6 +1507,11 @@ void Server::startBattle(int id1, int id2, const ChallengeInfo &c, int team1, in
     Player *p1 (player(id1));
     Player *p2 (player(id2));
 
+    TeamBattle battleTeam1 = *(new TeamBattle(p1->team(team1)));
+    TeamBattle battleTeam2 = *(new TeamBattle(p2->team(team2)));
+
+    myengine->beforeBattleStarted(id1,id2,c,id,battleTeam1,battleTeam2);
+
     QString tier = p1->team(team1).tier == p2->team(team2).tier ? p1->team(team1).tier : QString("Mixed %1").arg(GenInfo::Version(p1->team(team1).gen));
 
     printLine(QString("%1 battle between %2 and %3 started").arg(tier).arg(name(id1)).arg(name(id2)));
@@ -1522,7 +1525,7 @@ void Server::startBattle(int id1, int id2, const ChallengeInfo &c, int team1, in
         p2->relay().sendPlayer(p1->bundle());
     }
 
-    battles->startBattle(player(id1), player(id2), c, id, team1, team2);
+    battles->startBattle(player(id1), player(id2), c, id, battleTeam1, battleTeam2);
 
     Battle battleS = battleList[id];
 


### PR DESCRIPTION
Instead of changing the player's team, it changes a copy of the player's team which is the team used in battles. Made it so that the script functions can change a team by reference, but they still support changing the player's team using the slot number if needed. 100 is an arbitrary number, but the point is that the client only lets the player have six teams, and memory addresses that low aren't going to be allocated.

This does mess up the /showteam command for Battle Factory though :(. If you want that to work with this the command would have to get the team from the battle server.