### PR TITLE
Remove Missingno from Stats

### DIFF
--- a/src/server-plugins/UsageStatistics/usagestats.cpp
+++ b/src/server-plugins/UsageStatistics/usagestats.cpp
@@ -43,6 +43,10 @@ void TierRank::addUsage(const Pokemon::uniqueId &pokemon)
 {
     QMutexLocker l(&m);
 
+    if (pokemon == Pokemon::NoPoke) {
+        return;
+    }
+
     if (!positions.contains(pokemon)) {
         if (!PokemonInfo::IsAesthetic(pokemon)) {
             positions.insert(pokemon, uses.size());


### PR DESCRIPTION
I was trying to figure out how to remove pokemon that aren't included (BF, 1v1, etc), with ```TierMachine``` and ```numberOfPokemons``` but I couldn't get anything that looked like it would work and without a reliable way to test I just skipped it