### PR TITLE
Fix new battle window lag on Mac

### DIFF
--- a/src/libraries/BattleManager/battlescene.cpp
+++ b/src/libraries/BattleManager/battlescene.cpp
@@ -55,10 +55,15 @@ BattleScene::BattleScene(battledata_ptr dat, BattleDefaultTheme *theme, QVariant
     // Set optimizations not already done in QDeclarativeView
     mWidget->setAttribute(Qt::WA_OpaquePaintEvent);
     mWidget->setAttribute(Qt::WA_NoSystemBackground);
+
+    // Using OpenGL for the viewport causes horrible lag on Mac
+    
+#ifndef Q_OS_MACX
     // Make QDeclarativeView use OpenGL backend
     QGLWidget *glWidget = new QGLWidget(mWidget);
     mWidget->setViewport(glWidget);
     mWidget->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+#endif
 
     mWidget->engine()->rootContext()->setContextProperty("battle", mOwnProxy);
     mWidget->engine()->addImageProvider("pokeinfo", new PokemonInfoAccessor());


### PR DESCRIPTION
Using OpenGL as the viewport for the new battle window makes the entire app freeze up, so on Mac, just use the default raster viewport.