### PR TITLE
Fixed autocomplete when switching to a teams with different gens

### DIFF
--- a/src/Teambuilder/Teambuilder/teambuilder.cpp
+++ b/src/Teambuilder/Teambuilder/teambuilder.cpp
@@ -499,6 +499,7 @@ void TeamBuilder::markTeamUpdated()
     if (team().team().gen() != lastGen) {
         if (ui->gens.contains(team().team().gen())) {
             lastGen = team().team().gen();
+            dynamic_cast<PokeTableModel *>(pokemonModel)->setGen(lastGen);
             ui->gens[lastGen]->setChecked(true);
         }
     }


### PR DESCRIPTION
After switching to a team with a different gen, pokemonModel doesn't update, so the autocompleter is still looking through a list of the old mons. (i.e. edit a gen 1 team, then edit a gen 6 team, can't find tyrenitr)

this just calls PokeTableModel::setGen when the team is updated to fix the model.