### PR TITLE
Grab registry announcement from main site instead

### DIFF
--- a/src/Teambuilder/serverchoice.h
+++ b/src/Teambuilder/serverchoice.h
@@ -2,6 +2,7 @@
 #define SERVERCHOICE_H
 
 #include "centralwidget.h"
+#include <QtNetwork>
 
 struct ServerInfo;
 class TeamHolder;
@@ -40,6 +41,7 @@ private slots:
     void connected();
     void anchorClicked(const QUrl&);
     void timeout();
+    void announcementReceived(QNetworkReply* reply);
 
     void on_switchPort_clicked();
 private:
@@ -52,8 +54,9 @@ private:
 
     bool wasConnected;
     TeamHolder *team;
-
+    QNetworkAccessManager manager;
     void addSavedServer(const QString &ip, const QString &name="");
+    void getAnnouncement();
 };
 
 #endif // SERVERCHOICE_H


### PR DESCRIPTION
Basically, save the HTML file on PO site server instead, PO grabs it at startup, saves it incase in the future we don't have an internet connection (honestly this part is largely useless and unneeded, I do that a lot :v), and displays it where the old registry announcement used to be.

There is a very noticeable delay on startup though. Maybe a second or so long. Could be my poor internet, but a lot of our users have that issue. It's probably a non-issue really, but yeah. I'm not entirely sure why this happens, since it's an async call (which you can see by the delay of the announcement appearing), oh well.

Also I'm not sure why I kept getAnnouncement a function. Originally it was 5 lines (and a slot), but I managed to compress it so it probably shouldn't exist, but oh well :D.

Also thinking about it, having the announcement file on Github might be better