### PR TITLE
Add 997 cap +2 for RBY, implement Belly Drum correctly for GSC

### DIFF
--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -700,37 +700,37 @@ int BattleRBY::calculateDamage(int p, int t)
         def = crit ? this->poke(t).normalStat(SpAttack) : getStat(t, SpAttack);
     }
 
-    //burn
+    // burn
     if (!crit) {
-        //Burn does not halve the attack stat during damage calculation of Critical hits in RBY
+        // Burn does not halve the attack stat during damage calculation of Critical hits in RBY
         attack = attack / ((poke.status() == Pokemon::Burnt && cat == Move::Physical) ? 2 : 1);
-        //Minimum attack is set to 1
+        // Minimum attack is set to 1
         if (attack == 0) {
             attack = 1;
         }
     }
     /* Light screen / Reflect */
-    //In RBY, Reflect / Light Screen boost doesn't cap the stat at 999 or 1023
-    if ( !crit && pokeMemory(t).value("Barrier" + QString::number(cat) + "Count").toInt() > 0) {
-        def*=2;
+    // In RBY, Reflect / Light Screen boost doesn't cap the stat at 999 or 1023
+    if (!crit && pokeMemory(t).value("Barrier" + QString::number(cat) + "Count").toInt() > 0) {
+        def *= 2;
     }
 
     // In RBY, if either stat is higher than 255, both are quartered during damage calculation
     if (def > 255 || attack > 255) {
-        def = (def/4) % 256;
+        def = (def / 4) % 256;
         if (def == 0)
             def = 1;
 
-        attack = (attack/4) % 256;
+        attack = (attack / 4) % 256;
         if (attack == 0)
             attack = 1;
     }
 
     attack = std::min(attack, 65535);
 
-    if ( (attackused == Move::Explosion || attackused == Move::Selfdestruct)) {
+    if (attackused == Move::Explosion || attackused == Move::Selfdestruct) {
         /* explosion / selfdestruct */
-        def/=2;
+        def /= 2;
         if (def == 0)
             // prevent division by zero
             def = 1;
@@ -738,13 +738,14 @@ int BattleRBY::calculateDamage(int p, int t)
 
     int stab = turnMem(p).stab;
     int typemod = turnMem(p).typeMod;
-    int randnum = randint(38) + 217;
+    int randnum = randint(39) + 217;
     int power = tmove(p).power;
 
     power = std::min(power, 65535);
-    int damage = ((std::min(((level * ch * 2 / 5) + 2) * power, 65535) * attack / def) / 50) + 2;
+    int damage = ((std::min(((level * ch * 2 / 5) + 2) * power, 65535) * attack / def) / 50);
+    damage = std::min(damage, 997) + 2;
 
-    damage = (damage * stab/2) ;
+    damage = (damage * stab / 2) ;
     while (typemod > 0) {
         damage *= 2;
         typemod--;


### PR DESCRIPTION
So before adding 2 to damage in RBY, it needs to be capped at 997.

In GSC Belly Drum will keep adding +2 until either one of two things happen, the stat reaches 999, or the stat reaches +6. This means a Snorlax at +0 will reach +6, but one at +1 will reach +5. This is semi-relevant due to the popular usage of Growl and Charm users in the GSC metagame, who become slightly less effective in specific scenarios. This is how it works according to Crystal_ if I'm interpreting what he said correctly.