### PR TITLE
Fix Evasion moves in Gen 1

### DIFF
--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -811,7 +811,7 @@ bool BattleRBY::loseStatMod(int player, int stat, int malus, int attacker, bool 
 bool BattleRBY::gainStatMod(int player, int stat, int bonus, int, bool tell)
 {
     int boost = fpoke(player).boosts[stat];
-    if (boost < 6 && getStat(player, stat) < 999) {
+    if (boost < 6 && (getStat(player, stat) < 999 || stat == Evasion)) {
         notify(All, StatChange, player, qint8(stat), qint8(bonus), !tell);
         changeStatMod(player, stat, std::min(boost+bonus, 6));
     } else {


### PR DESCRIPTION
It seems to fix the cap after one boost, but the tooltip is still wrong (visually, the attack stat is raised, no actual boost). It has probably something to do with the fact that there is one less stat in Gen 1 (only Special stat).
http://pokemon-online.eu/threads/yellow-gen-double-team.31336/