### PR TITLE
Fix Confusion damage with substitute

### DIFF
--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -1918,7 +1918,7 @@ void BattleBase::inflictConfusedDamage(int player)
     /* If both you and your opponent have subs, the miss "recoil" will be dealt to the opponent's sub
      * If only you have a sub, the recoil damage is discarded */
     if (hasSubstitute(player)) {
-        if (hasSubstitute(opponent(player)) && gen() <= 1) {
+        if (hasSubstitute(opponent(player)) && gen().num <= 1) {
             inflictDamage(opponent(player), damage, player, true, true); //in RBY the damage is to the sub
         } else {
             inflictDamage(player, damage, player, true, false); // otherwise the damage is dealt to the pokemon

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -1918,7 +1918,7 @@ void BattleBase::inflictConfusedDamage(int player)
     /* If both you and your opponent have subs, the miss "recoil" will be dealt to the opponent's sub
      * If only you have a sub, the recoil damage is discarded */
     if (hasSubstitute(player)) {
-        if (hasSubstitute(opponent(player)) && gen().num <= 1) {
+        if (hasSubstitute(opponent(player)) && gen().num == 1) {
             inflictDamage(opponent(player), damage, player, true, true); //in RBY the damage is to the sub
         } else {
             inflictDamage(player, damage, player, true, false); // otherwise the damage is dealt to the pokemon

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -1918,8 +1918,10 @@ void BattleBase::inflictConfusedDamage(int player)
     /* If both you and your opponent have subs, the miss "recoil" will be dealt to the opponent's sub
      * If only you have a sub, the recoil damage is discarded */
     if (hasSubstitute(player)) {
-        if (hasSubstitute(opponent(player))) {
-            inflictDamage(opponent(player), damage, player, true, gen() <= 1); //in RBY the damage is to the sub
+        if (hasSubstitute(opponent(player)) && gen() <= 1) {
+            inflictDamage(opponent(player), damage, player, true, true); //in RBY the damage is to the sub
+        } else {
+            inflictDamage(player, damage, player, true, false); // otherwise the damage is dealt to the pokemon
         }
     } else {
         inflictDamage(player, damage, player, true, gen() <= 1); //in RBY the damage is to the sub


### PR DESCRIPTION
http://pokemon-online.eu/threads/substitute-and-confusion.31373/#post-440847

I hope that everything is correct. ^^'
And is there a reason why it is "gen() <=1" and not "gen() == 1", or can i change it?
