### PR TITLE
New script engine methods, sys.makeServerPublic() changes config

### DIFF
--- a/src/Server/scriptengine.h
+++ b/src/Server/scriptengine.h
@@ -170,14 +170,22 @@ public:
     Q_INVOKABLE QScriptValue createChannel(const QString &channame);
     Q_INVOKABLE QScriptValue getAnnouncement();
     Q_INVOKABLE void changeColor(int id, const QString &color);
+    Q_INVOKABLE void changeColorStrict(int id, const QString &color);
     Q_INVOKABLE QScriptValue getColor(int id);
 
     Q_INVOKABLE void setAnnouncement(const QString &html, int id);
     Q_INVOKABLE void setAnnouncement(const QString &html);
     Q_INVOKABLE void changeAnnouncement(const QString &html);
-
     Q_INVOKABLE QString getDescription();
     Q_INVOKABLE void changeDescription(const QString &html);
+    Q_INVOKABLE QString getServerName();
+    Q_INVOKABLE void changeServerName(const QString &name);
+
+    Q_INVOKABLE QScriptValue serverPorts();
+    Q_INVOKABLE QScriptValue proxyServers();
+    Q_INVOKABLE QScriptValue trustedIps();
+    Q_INVOKABLE void addTrustedIp(const QString &ip);
+    Q_INVOKABLE void removeTrustedIp(const QString &ip);
 
     Q_INVOKABLE void makeServerPublic(bool isPublic);
 

--- a/src/Server/server.cpp
+++ b/src/Server/server.cpp
@@ -248,6 +248,7 @@ void Server::start(){
     safeScripts = s.value("Scripts/SafeMode").toBool();
     overactiveShow = s.value("AntiDOS/ShowOveractiveMessages").toBool();
     proxyServers = s.value("Network/ProxyServers").toString().split(",");
+    trustedIps = s.value("AntiDOS/TrustedIps").toString().split(",");
     passwordProtected = s.value("Server/RequirePassword").toBool();
     serverPassword = s.value("Server/Password").toByteArray();
     zippedTiers = makeZipPacket(NetworkServ::TierSelection, TierMachine::obj()->tierList());
@@ -1417,6 +1418,15 @@ void Server::proxyServersChanged(const QString &ips)
         return;
     proxyServers = ips.split(",");
     forcePrint("Proxy Servers setting changed");
+}
+
+void Server::trustedIpsChanged(const QString &ips)
+{
+    QStringList newlist = ips.split(",");
+    if (trustedIps == newlist)
+        return;
+    trustedIps = ips.split(",");
+    forcePrint("Trusted IPs setting changed");
 }
 
 void Server::serverPasswordChanged(const QString &pass)

--- a/src/Server/server.h
+++ b/src/Server/server.h
@@ -146,6 +146,7 @@ public slots:
     void safeScriptsChanged(bool safeScripts);
     void overactiveToggleChanged(bool overactiveToggle);
     void proxyServersChanged(const QString &ips);
+    void trustedIpsChanged(const QString &ips);
     void serverPasswordChanged(const QString &pass);
     void usePasswordChanged(bool usePass);
     void changeDbMod(const QString &mod);
@@ -222,6 +223,7 @@ private:
     quint16 serverPrivate, serverPlayerMax;
     QList<quint16>  serverPorts;
     QStringList proxyServers;
+    QStringList trustedIps;
     bool showLogMessages;
     bool useChannelFileLog;
     int amountOfInactiveDays;


### PR DESCRIPTION
sys.changeColorStrict(id, color): version of sys.changeColor() that checks for the regular PO color limitations (brightness, lightness, greenness not too high), and does nothing if the limits are exceeded.
sys.changeServerName(name): changes server name.
sys.getServerName(): returns server name.
sys.serverPorts(): returns an array of server ports.
sys.proxyServers(): returns an array of proxy servers.
sys.trustedIps(): returns an array of trusted IPs.
sys.addTrustedIp(ip): adds a trusted IP to the antidos.
sys.removeTrustedIp(ip): removes a trusted IP from the antidos.

server.cpp has a trustedIpsChanged(ips) method and a trustedIps variable added for the trusted IP sys methods.

As for sys.makeServerPublic(), it wouldn't update the config, so your server would revert to the original public/private setting after restarting. It will now update the config, so changing public/private with the method will now stay even if you restart.