### PR TITLE
Fix Magic Guard + Spiky Shield

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -7265,7 +7265,7 @@ struct MMSpikyShield : public MM
         }
         b.fail(s, 27, 0, Pokemon::Grass, t);
 
-        if ((tmove(b, s).flags & Move::ContactFlag) ) {
+        if ((tmove(b, s).flags & Move::ContactFlag) && !b.hasWorkingAbility(t, Ability::MagicGuard) ) {
             b.inflictDamage(s,b.poke(s).totalLifePoints()/6,s,false);
             b.sendMoveMessage(209,0,s);
             return;


### PR DESCRIPTION
http://pokemon-online.eu/threads/magic-guard-vs-spiky-shield.32480/
In-game test aren't done yet, but I am pretty sure that Magic Guard should prevent Spiky Shield damage.
This can be merged once in-game tests are done.
Can't test it right now, because of lack of time, but I can probably test the PR tomorrow if it is necessary.