### PR TITLE
Fix Keldeo in Teambuilder/Battle

### DIFF
--- a/src/Teambuilder/Teambuilder/pokeedit.cpp
+++ b/src/Teambuilder/Teambuilder/pokeedit.cpp
@@ -417,8 +417,7 @@ void PokeEdit::setNum(Pokemon::uniqueId num)
                     poke().setMove(Move::SecretSword, 0, false);
                 }
             } else if (PokemonInfo::Released(Pokemon::Keldeo_R, poke().gen())) {
-                if (poke().gen() < 6)
-                    poke().removeMove(Move::SecretSword);
+                poke().removeMove(Move::SecretSword);
             }
         } else if (num.pokenum == Pokemon::Giratina) {
             if (num == Pokemon::Giratina_O && poke().item() != Item::GriseousOrb) {

--- a/src/libraries/PokemonInfo/battlestructs.cpp
+++ b/src/libraries/PokemonInfo/battlestructs.cpp
@@ -174,8 +174,7 @@ void PokeBattle::init(PokePersonal &poke)
         }
 
         if (num() == Pokemon::Keldeo_R && !poke.hasMove(Move::SecretSword)) {
-            if (p.gen() < 6)
-                num() = Pokemon::Keldeo;
+            num() = Pokemon::Keldeo;
         }
 
         Pokemon::uniqueId ori = PokemonInfo::OriginalForme(num());

--- a/src/libraries/PokemonInfo/pokemonstructs.cpp
+++ b/src/libraries/PokemonInfo/pokemonstructs.cpp
@@ -315,16 +315,6 @@ void PokePersonal::runCheck(bool hack)
 
         MoveSetChecker::isValid(num(), gen(), move(0), move(1), move(2), move(3), ability(), gender(), level(), false, &invalidMoves);
     }
-
-    if (num().pokenum == Pokemon::Keldeo) {
-        if (gen() < 6) {
-            if (move(0) == Move::SecretSword || move(1) == Move::SecretSword || move(2) == Move::SecretSword || move(3) == Move::SecretSword) {
-                num() = Pokemon::Keldeo_R;
-            } else {
-                num() = num().original();
-            }
-        }
-    }
 }
 
 int PokePersonal::addMove(int moveNum, bool check) throw(QString)


### PR DESCRIPTION
http://pokemon-online.eu/threads/regular-keldeo-with-secret-sword-in-bw2.32634/
It is partially a revert of PR #1030 , because regular Keldeo can also have Secret Sword in BW2, not just in Gen 6. I also removed the check in pokemonstructs.cpp , because otherwise the Keldeo-R spirte will be loaded in a battle, although you have selected regular Keldeo in the teambuilder.
Hope that I didn't break anything ^^