### PR TITLE
Fix Magic Guard + (High) Jump Kick recoil

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -3835,34 +3835,36 @@ struct MMJumpKick : public MM
     }
 
     static void asf(int s, int t, BS &b) {
-        int damage;
-        if (b.gen() >= 5)
-            damage = b.poke(s).totalLifePoints()/2;
-        else {
-            int typemod;
-            int typeadv[] = {b.getType(t, 1), b.getType(t, 2)};
-            int type = MM::type(b,s);
-            if (typeadv[0] == Type::Ghost) {
-                if (b.gen() <= 3)
-                    return;
-                typemod = b.convertTypeEff(TypeInfo::Eff(type, typeadv[1]));
-            } else if (typeadv[1] == Type::Ghost) {
-                if (b.gen() <= 3)
-                    return;
-                typemod = b.convertTypeEff(TypeInfo::Eff(type, typeadv[0]));
-            } else {
-                typemod = b.convertTypeEff(TypeInfo::Eff(type, typeadv[0])) + b.convertTypeEff(TypeInfo::Eff(type, typeadv[1]));
-            }
+        if (!b.hasWorkingAbility(s, Ability::MagicGuard)) {
+            int damage;
+            if (b.gen() >= 5)
+                damage = b.poke(s).totalLifePoints()/2;
+            else {
+                int typemod;
+                int typeadv[] = {b.getType(t, 1), b.getType(t, 2)};
+                int type = MM::type(b,s);
+                if (typeadv[0] == Type::Ghost) {
+                    if (b.gen() <= 3)
+                        return;
+                    typemod = b.convertTypeEff(TypeInfo::Eff(type, typeadv[1]));
+                } else if (typeadv[1] == Type::Ghost) {
+                    if (b.gen() <= 3)
+                        return;
+                    typemod = b.convertTypeEff(TypeInfo::Eff(type, typeadv[0]));
+                } else {
+                    typemod = b.convertTypeEff(TypeInfo::Eff(type, typeadv[0])) + b.convertTypeEff(TypeInfo::Eff(type, typeadv[1]));
+                }
 
-            fturn(b,s).typeMod = typemod;
-            fturn(b,s).stab = b.hasType(s, Type::Fighting) ? 3 : 2;
-            if (b.gen().num == 4)
-                damage = std::min(b.calculateDamage(s,t)/2, b.poke(t).totalLifePoints()/2);
-            else
-                damage = std::min(b.calculateDamage(s,t)/8, b.poke(t).totalLifePoints()/2);
+                fturn(b,s).typeMod = typemod;
+                fturn(b,s).stab = b.hasType(s, Type::Fighting) ? 3 : 2;
+                if (b.gen().num == 4)
+                    damage = std::min(b.calculateDamage(s,t)/2, b.poke(t).totalLifePoints()/2);
+                else
+                    damage = std::min(b.calculateDamage(s,t)/8, b.poke(t).totalLifePoints()/2);
+            }
+            b.sendMoveMessage(64,0,s,Type::Fighting);
+            b.inflictDamage(s, damage, s, true);
         }
-        b.sendMoveMessage(64,0,s,Type::Fighting);
-        b.inflictDamage(s, damage, s, true);
     }
 };
 


### PR DESCRIPTION
http://pokemon-online.eu/threads/magic-guard-should-ignore-high-jump-kicks-miss-recoil.32777/
The diff looks big, but I only put everything into ` if (!b.hasWorkingAbility(s, Ability::MagicGuard)) {` and aligned the rest.
I did a quick test and it seems to work as it should