### PR TITLE
Improve "... was dragged out" move message

### DIFF
--- a/bin/db/moves/move_message.txt
+++ b/bin/db/moves/move_message.txt
@@ -71,7 +71,7 @@
 104 %s prepared a gust of wind!|%s became cloaked in a harsh light!|%s tucked in its head!|%s absorbed light!|%s became cloaked in a freezing light!|%s became cloaked in freezing air!|%s is becoming one with the earth!
 105 %s recycled %i!
 106 %s went to sleep and became healthy!
-107 %f held on to the ground using its Suction Cups!|%f is solidly rooted to the ground!|%f was dragged out!
+107 %f held on to the ground using its Suction Cups!|%f is solidly rooted to the ground!|%e was dragged out!
 108 %s copied %f's %a!
 109 %ts's team became cloaked in a mystical veil!|%ts's team is no longer protected by Safeguard!|Safeguard prevents %f from being inflicted by status!
 111 %s sketched %m!

--- a/src/libraries/BattleManager/battleclientlog.cpp
+++ b/src/libraries/BattleManager/battleclientlog.cpp
@@ -335,7 +335,8 @@ void BattleClientLog::onMoveMessage(int spot, int move, int part, int type, int 
     mess.replace("%q", q);
     mess.replace("%i", ItemInfo::Name(other));
     mess.replace("%a", AbilityInfo::Name(other));
-    mess.replace("%p", PokemonInfo::Name(other));
+    mess.replace("%p", PokemonInfo::Name(other)); //for Transform
+    mess.replace("%e", PokemonInfo::Name(data()->poke(foe).num())); // for "... was dragged out" message
     printHtml("MoveMessage", toColor(escapeHtml(tu(mess)), theme()->typeColor(type)));
 }
 


### PR DESCRIPTION
Now it always shows the name of the pokemon and not not the nickname (if
it has one).

http://pokemon-online.eu/threads/dragged-out-pokemon-have-no-species.14761/