### PR TITLE
Damage Calc: Add Happiness selection & minor tweaks

### DIFF
--- a/src/Teambuilder/damagecalc.cpp
+++ b/src/Teambuilder/damagecalc.cpp
@@ -74,6 +74,8 @@ DamageCalc::DamageCalc(int gen, QWidget *parent) :
     connect(ui->mygender, SIGNAL(currentIndexChanged(int)), this, SLOT(updateMyPokePic()));
     connect(ui->ogender, SIGNAL(currentIndexChanged(int)), this, SLOT(updateOPokePic()));
 
+    connect(ui->happiness, SIGNAL(valueChanged(int)), this, SLOT(updateMoveInfo()));
+
     connect(ui->calculate, SIGNAL(clicked()), this, SLOT(calculate()));
 }
 
@@ -319,6 +321,23 @@ void DamageCalc::updateMoveInfo()
 {
     int move = MoveInfo::Number(ui->move->currentText());
     int bp = MoveInfo::Power(move, m_currentGen);
+    int happiness = ui->happiness->value();
+    if (move == Move::Frustration) {
+        bp = std::max((255 - happiness) * 2 / 5, 1);
+    } else if (move == Move::Return) {
+        bp = std::max(happiness * 2 / 5, 1);
+    }
+    // TODO: The code below doesn't work correctly
+    /**else if (move == Move::GyroBall) {
+        bp = 25 * ((ui->ospdstat->text()).toInt() / (ui->myspdstat->text()).toInt());
+        if (bp > 150) {
+            bp = 150;
+        }
+    } else if (move == Move::WringOut || move == Move::CrushGrip) {
+        bp = 1 + 120 * ((ui->ohpstat->text()).toInt() / (ui->myhpstat->text()).toInt());
+    }
+    */
+
     int type = MoveInfo::Type(move, m_currentGen);
     int category = MoveInfo::Category(move, m_currentGen);
 

--- a/src/Teambuilder/damagecalc.ui
+++ b/src/Teambuilder/damagecalc.ui
@@ -193,14 +193,14 @@
            <item>
             <layout class="QVBoxLayout" name="verticalLayout">
              <item>
-              <widget class="QLabel" name="label_8">
+              <widget class="QLabel" name="mypokemonLabel">
                <property name="text">
                 <string>Pokemon:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label">
+              <widget class="QLabel" name="mylevelLabel">
                <property name="text">
                 <string>Level:</string>
                </property>
@@ -221,49 +221,49 @@
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_12">
+              <widget class="QLabel" name="mystatusLabel">
                <property name="text">
                 <string>Status:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_2">
+              <widget class="QLabel" name="myHpLabel">
                <property name="text">
                 <string>HP:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_3">
+              <widget class="QLabel" name="myattackLabel">
                <property name="text">
                 <string>Attack:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_4">
+              <widget class="QLabel" name="mydefenseLabel">
                <property name="text">
                 <string>Defense:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_5">
+              <widget class="QLabel" name="myspattackLabel">
                <property name="text">
                 <string>Special Attack:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_6">
+              <widget class="QLabel" name="myspdefenselabel">
                <property name="text">
                 <string>Special Defense:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_7">
+              <widget class="QLabel" name="myspeedLabel">
                <property name="text">
                 <string>Speed:</string>
                </property>
@@ -908,14 +908,14 @@
            <item>
             <layout class="QVBoxLayout" name="verticalLayout_10">
              <item>
-              <widget class="QLabel" name="label_37">
+              <widget class="QLabel" name="opokemonLabel">
                <property name="text">
                 <string>Pokemon:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_38">
+              <widget class="QLabel" name="olevelLabel">
                <property name="text">
                 <string>Level:</string>
                </property>
@@ -936,49 +936,49 @@
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_41">
+              <widget class="QLabel" name="ostatusLabel">
                <property name="text">
                 <string>Status:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_42">
+              <widget class="QLabel" name="oHpLabel">
                <property name="text">
                 <string>HP:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_43">
+              <widget class="QLabel" name="oattackLabel">
                <property name="text">
                 <string>Attack:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_44">
+              <widget class="QLabel" name="odefenseLabel">
                <property name="text">
                 <string>Defense:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_45">
+              <widget class="QLabel" name="ospattackLabel">
                <property name="text">
                 <string>Special Attack:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_46">
+              <widget class="QLabel" name="ospdefenseLabel">
                <property name="text">
                 <string>Special Defense:</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QLabel" name="label_47">
+              <widget class="QLabel" name="ospeedLabel">
                <property name="text">
                 <string>Speed:</string>
                </property>
@@ -1446,7 +1446,7 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QLabel" name="label_14">
+      <widget class="QLabel" name="moveLabel">
        <property name="text">
         <string>Move:</string>
        </property>
@@ -1460,7 +1460,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_15">
+      <widget class="QLabel" name="movepowerLabel">
        <property name="text">
         <string>Base Power:</string>
        </property>
@@ -1474,7 +1474,24 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label_16">
+      <widget class="QLabel" name="happinessLabel">
+       <property name="text">
+        <string>Happiness:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="happiness">
+       <property name="maximum">
+        <number>255</number>
+       </property>
+       <property name="value">
+        <number>255</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="movetypeLabel">
        <property name="text">
         <string>Type:</string>
        </property>
@@ -1484,7 +1501,7 @@
       <widget class="QComboBox" name="movetype"/>
      </item>
      <item>
-      <widget class="QLabel" name="label_17">
+      <widget class="QLabel" name="movecategoryLabel">
        <property name="text">
         <string>Category:</string>
        </property>
@@ -1517,7 +1534,7 @@
       <widget class="QComboBox" name="weather"/>
      </item>
      <item>
-      <widget class="QLabel" name="label_13">
+      <widget class="QLabel" name="genLabel">
        <property name="text">
         <string>Gen:</string>
        </property>


### PR DESCRIPTION
Add a QSpinBox for Happiness selection, rename QLabels and add
calculation for Return/Frustration.
Calculations for Gyro Ball/Wring Out/Crush Grip aren't working, I will try to fix it
another time.