### PR TITLE
Fix Battle Music/Pokemon Cries settings  & add option to hide banner

### DIFF
--- a/src/Teambuilder/basebattlewindow.cpp
+++ b/src/Teambuilder/basebattlewindow.cpp
@@ -137,13 +137,15 @@ void BaseBattleWindow::init()
     bool saveLog = settings.value("Battle/SaveLogs").toBool();
     mylayout->addWidget(saveLogs = new QCheckBox(tr("Save log")), 1, 0, 1, 1);
     saveLogs->setChecked(saveLog);
-    mylayout->addWidget(musicOn = new QCheckBox(tr("Music")), 1, 1, 1, 1);
-    mylayout->addWidget(flashWhenMoveDone = new QCheckBox(tr("Flash when a move is done")), 1, 2, 1, 1);
-    mylayout->addWidget(alwaysOnTop = new QCheckBox(tr("Always on top")), 1, 3, 1, 1);
+    mylayout->addWidget(battleMusicOn = new QCheckBox(tr("Battle Music")), 1, 1, 1, 1);
+    mylayout->addWidget(pokemonCriesOn = new QCheckBox(tr("Pokemon Cries")), 1, 2, 1, 1);
+    mylayout->addWidget(flashWhenMoveDone = new QCheckBox(tr("Flash when a move is done")), 1, 3, 1, 1);
+    mylayout->addWidget(alwaysOnTop = new QCheckBox(tr("Always on top")), 1, 4, 1, 1);
     alwaysOnTop->setChecked(settings.value("Battle/AlwaysOnTop").toBool());
 
     QSettings s;
-    musicOn->setChecked(s.value("BattleAudio/PlayMusic").toBool() || s.value("play_battle_cries").toBool());
+    battleMusicOn->setChecked(s.value("BattleAudio/PlayMusic").toBool());
+    pokemonCriesOn->setChecked(s.value("BattleAudio/PlaySounds").toBool());
     flashWhenMoveDone->setChecked(s.value("Battle/FlashOnMove").toBool());
 
     QVBoxLayout *chat = new QVBoxLayout();
@@ -159,7 +161,8 @@ void BaseBattleWindow::init()
     buttons->addWidget(myignore = new QPushButton(tr("&Ignore spectators")));
     buttons->addWidget(mycalc = new QPushButton(tr("&Damage Calc")));
 
-    connect(musicOn, SIGNAL(toggled(bool)), SLOT(musicPlayStop()));
+    connect(battleMusicOn, SIGNAL(toggled(bool)), SLOT(musicPlayStop()));
+    connect(pokemonCriesOn, SIGNAL(toggled(bool)), SLOT(criesPlayStop()));
     connect(myignore, SIGNAL(clicked()), SLOT(ignoreSpectators()));
     connect(myclose, SIGNAL(clicked()), SLOT(clickClose()));
     connect(myline, SIGNAL(returnPressed()), this, SLOT(sendMessage()));
@@ -193,12 +196,18 @@ void BaseBattleWindow::init()
     undelayOnSounds = true;
 
     musicPlayStop();
+    criesPlayStop();
     alwaysOnTopChanged(alwaysOnTop->isChecked());
 }
 
 bool BaseBattleWindow::musicPlayed() const
 {
-    return musicOn->isChecked();
+    return battleMusicOn->isChecked();
+}
+
+bool BaseBattleWindow::criesPlayed() const
+{
+    return pokemonCriesOn->isChecked();
 }
 
 bool BaseBattleWindow::flashWhenMoved() const
@@ -227,7 +236,6 @@ void BaseBattleWindow::changeMusicVolume(int v)
 void BaseBattleWindow::musicPlayStop()
 {
     if (!musicPlayed()) {
-        playBattleCries() = false;
         playBattleMusic() = false;
 #ifdef QT5
         audio->pause();
@@ -240,15 +248,12 @@ void BaseBattleWindow::musicPlayStop()
     QSettings s;
 #ifdef QT5
     audio->setVolume(s.value("BattleAudio/MusicVolume").toInt());
-    cry->setVolume(float(s.value("BattleAudio/CryVolume").toInt())/100);
 #else
     audioOutput->setVolume(float(s.value("BattleAudio/MusicVolume").toInt())/100);
-    cryOutput->setVolume(float(s.value("BattleAudio/CryVolume").toInt())/100);
 #endif
 
     if (musicPlayed()) {
-        playBattleCries() = s.value("BattleAudio/PlaySounds").toBool();
-        playBattleMusic() = s.value("BattleAudio/PlayMusic").toBool() || !s.value("play_battle_cries").toBool();
+        playBattleMusic() = s.value("BattleAudio/PlayMusic").toBool();
     }
 
     if (!playBattleMusic()) {
@@ -291,6 +296,24 @@ void BaseBattleWindow::musicPlayStop()
 #endif
 
 }
+
+void BaseBattleWindow::criesPlayStop()
+{
+    if (!criesPlayed())
+        playBattleCries() = false;
+
+    QSettings s;
+#ifdef QT5
+    cry->setVolume(float(s.value("BattleAudio/CryVolume").toInt())/100);
+#else
+    cryOutput->setVolume(float(s.value("BattleAudio/CryVolume").toInt())/100);
+#endif
+
+    if (criesPlayed()) {
+        playBattleCries() = s.value("BattleAudio/PlaySounds").toBool();
+    }
+}
+
 
 void BaseBattleWindow::enqueueMusic()
 {

--- a/src/Teambuilder/basebattlewindow.cpp
+++ b/src/Teambuilder/basebattlewindow.cpp
@@ -132,7 +132,7 @@ void BaseBattleWindow::init()
     QHBoxLayout *columns = new QHBoxLayout(this);
     columns->addLayout(mylayout = new QGridLayout());
 
-    mylayout->addWidget(getSceneWidget(), 0, 0, 1, 4);
+    mylayout->addWidget(getSceneWidget(), 0, 0, 1, 5);
     QSettings settings;
     bool saveLog = settings.value("Battle/SaveLogs").toBool();
     mylayout->addWidget(saveLogs = new QCheckBox(tr("Save log")), 1, 0, 1, 1);

--- a/src/Teambuilder/basebattlewindow.h
+++ b/src/Teambuilder/basebattlewindow.h
@@ -98,6 +98,7 @@ public:
     void onBattleEnd(int res, int winner);
 
     bool musicPlayed() const;
+    bool criesPlayed() const;
     bool flashWhenMoved() const;
     virtual void disable();
 
@@ -117,6 +118,7 @@ public slots:
     void ignoreSpectators();
 
     void musicPlayStop();
+    void criesPlayStop();
     void enqueueMusic();
 #ifdef QT5
     void criesProblem(QAudio::State newState);
@@ -139,7 +141,8 @@ protected:
     QPushButton *myclose, *mysend, *myignore, *mycalc;
 
     QCheckBox *saveLogs;
-    QCheckBox *musicOn;
+    QCheckBox *battleMusicOn;
+    QCheckBox *pokemonCriesOn;
     QCheckBox *flashWhenMoveDone;
     QCheckBox *alwaysOnTop;
 

--- a/src/Teambuilder/battlewindow.cpp
+++ b/src/Teambuilder/battlewindow.cpp
@@ -108,10 +108,10 @@ BattleWindow::BattleWindow(int battleId, const PlayerInfo &me, const PlayerInfo 
     setWindowTitle(tr("Battling against %1").arg(name(info().opponent)));
 
     myclose->setText(tr("&Forfeit"));
-    mylayout->addWidget(mytab = new QTabWidget(), 2, 0, 1, 4);
+    mylayout->addWidget(mytab = new QTabWidget(), 2, 0, 1, 5);
     mylayout->addWidget(mycancel = new QPushButton(tr("&Cancel")), 3, 0);
     mylayout->addWidget(myattack = new QPushButton(tr("&Attack")), 3, 1);
-    mylayout->addWidget(myswitch = new QPushButton(tr("&Switch Pokemon")), 3, 2, 1, 2);
+    mylayout->addWidget(myswitch = new QPushButton(tr("&Switch Pokemon")), 3, 2, 1, 3);
     mytab->setObjectName("Modified");
 
     mytab->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);

--- a/src/Teambuilder/client.cpp
+++ b/src/Teambuilder/client.cpp
@@ -1445,6 +1445,11 @@ QMenuBar * Client::createMenuBar(MainEngine *w)
     connect(oldShortcuts, SIGNAL(triggered(bool)), SLOT(useOldShortcuts(bool)));
     oldShortcuts->setChecked(globals.value("Client/UsingOldShortcuts").toBool());
 
+    QAction * hide_announcement = menuActions->addAction(tr("Hide announcement banner"));
+    hide_announcement->setCheckable(true);
+    connect(hide_announcement, SIGNAL(triggered(bool)), SLOT(toggleAnnouncementOption(bool)));
+    hide_announcement->setChecked(globals.value("Client/HideAnnouncement").toBool());
+
     mytiermenu = menuBar->addMenu(tr("&Tiers"));
     rebuildTierMenu();
 
@@ -1874,12 +1879,23 @@ void Client::serverNameReceived(const QString &sName)
 
 void Client::announcementReceived(const QString &ann)
 {
+    if (globals.value("Client/HideAnnouncement").toBool())
+        return;
+
     if (ann.length() == 0)
         return;
 
     server_announcement->setText(ann);
     server_announcement->setAlignment(Qt::AlignCenter);
     server_announcement->show();
+}
+
+void Client::toggleAnnouncementOption(bool hide)
+{
+    if (hide == true)
+        server_announcement->hide();
+    else
+        server_announcement->show();
 }
 
 void Client::tierListReceived(const QByteArray &tl)

--- a/src/Teambuilder/client.h
+++ b/src/Teambuilder/client.h
@@ -187,6 +187,7 @@ public slots:
     void playerLogin(const PlayerInfo &p, const QStringList &tiers, bool ignore=false);
     void playerReceived(const PlayerInfo &p);
     void announcementReceived(const QString &);
+    void toggleAnnouncementOption(bool hide);
     void tiersReceived(const QStringList &tiers);
     void playerLogout(int);
     void sendRegister();


### PR DESCRIPTION
Now the settings for Pokemon Cries and Battle Music are separated, so
you can now have only Pokemon Cries.

Also added an option to hide announcement banner (requested by Nightmare Moon).

Wanted to separate the PRs, but I accidentally updated the wrong branch and I am too lazy to fix this.