### PR TITLE
Prevent RBY stat change failure from compounding paralysis/burn

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -503,18 +503,10 @@ void BattleSituation::endTurn()
 
 void BattleSituation::endTurnDefrost()
 {
-    // RBY freeze is forever unless hit by fire moves.
-    // We think both stadium and cart have permafreeze.
-    if (gen().num == 1) {
-        return;
-    }
-    foreach(int player, speedsVector) {
-        if (poke(player).status() == Pokemon::Frozen)
-        {
-            if (coinflip(26, 255))
-            {
-                unthaw(player);
-            }
+    // Only gen 2 as it is supposed to get called at a different time
+    foreach (int player, speedsVector) {
+        if (poke(player).status() == Pokemon::Frozen && coinflip(26, 255)) {
+            unthaw(player);
         }
     }
 }
@@ -571,22 +563,20 @@ void BattleSituation::endTurnPoison(int player)
     if (koed(player)|| poke(player).status() != Pokemon::Poisoned)
         return;
 
-    //PoisonHeal
+    // PoisonHeal
     if (hasWorkingAbility(player, Ability::PoisonHeal)) {
         if (canHeal(player,HealByAbility,ability(player))) {
             sendAbMessage(45,0,player,0,Pokemon::Poison);
             healLife(player, poke(player).totalLifePoints()/8);
         }
-    } else {
-        if (!hasWorkingAbility(player, Ability::MagicGuard)) {
-            notify(All, StatusMessage, player, qint8(HurtPoison));
+    } else if (!hasWorkingAbility(player, Ability::MagicGuard)) {
+        notify(All, StatusMessage, player, qint8(HurtPoison));
 
-            if (poke(player).statusCount() == 0)
-                inflictDamage(player, poke(player).totalLifePoints()/ (gen().num == 1 ? 16 : 8), player); // 1/16 in gen 1
-            else {
-                inflictDamage(player, poke(player).totalLifePoints() * (16-poke(player).statusCount()) / 16, player);
-                //poke(player).statusCount() = std::max(1, poke(player).statusCount() - 1); //Already being applied earlier.
-            }
+        if (poke(player).statusCount() == 0)
+            inflictDamage(player, poke(player).totalLifePoints() / 8, player);
+        else {
+            inflictDamage(player, poke(player).totalLifePoints() * (16 - poke(player).statusCount()) / 16, player);
+            //poke(player).statusCount() = std::max(1, poke(player).statusCount() - 1); //Already being applied earlier.
         }
     }
     /* Toxic still increases under magic guard, poison heal */
@@ -604,7 +594,7 @@ void BattleSituation::endTurnBurn(int player)
 
     notify(All, StatusMessage, player, qint8(HurtBurn));
     //HeatProof: burn does only 1/16, also Gen 1 only does 1/16
-    inflictDamage(player, poke(player).totalLifePoints()/(8*(1+(hasWorkingAbility(player,Ability::Heatproof) || gen().num == 1))), player);
+    inflictDamage(player, poke(player).totalLifePoints() / (8 * (1 + hasWorkingAbility(player, Ability::Heatproof))), player);
 }
 
 BattleChoices BattleSituation::createChoice(int slot)
@@ -1106,20 +1096,16 @@ void BattleSituation::callseffects(int source, int target, const QString &name)
 
 void BattleSituation::callieffects(int source, int target, const QString &name)
 {
-    if (gen() <= 1 || !isOut(source))
-        return;
-    //Klutz
-    if (hasWorkingItem(source, poke(source).item())) {
+    if (isOut(source) && hasWorkingItem(source, poke(source).item())) {
         ItemEffect::activate(name, poke(source).item(), source, target, *this);
     }
 }
 
 void BattleSituation::callaeffects(int source, int target, const QString &name)
 {
-    if (gen() <= 2 || !isOut(source))
-        return;
-    if (hasWorkingAbility(source, ability(source)))
+    if (gen() > 2 && isOut(source) && hasWorkingAbility(source, ability(source))) {
         AbilityEffect::activate(name, ability(source), source, target, *this);
+    }
 }
 
 void BattleSituation::sendBack(int player, bool silent)
@@ -1209,8 +1195,7 @@ bool BattleSituation::testAccuracy(int player, int target, bool silent)
             return true;
     }
 
-    //No Guard. Acc 102 is used for Gen 1 moves that bypass Accuracy check
-    if ((hasWorkingAbility(player, Ability::NoGuard) || hasWorkingAbility(target, Ability::NoGuard)) || (gen().num == 1 && acc == 102)) {
+    if (hasWorkingAbility(player, Ability::NoGuard) || hasWorkingAbility(target, Ability::NoGuard)) {
         return true;
     }
 
@@ -1235,7 +1220,7 @@ bool BattleSituation::testAccuracy(int player, int target, bool silent)
     }
 
     if (MoveInfo::isOHKO(move, gen())) {
-        bool ret = coinflip(unsigned(30 + (gen().num == 1 ? 0 :  poke(player).level() - poke(target).level()) ), 100);
+        bool ret = coinflip(unsigned(30 + poke(player).level() - poke(target).level()), 100);
         if (!ret && !silent) {
             notifyMiss(multiTar, player, target);
         }
@@ -1293,56 +1278,37 @@ void BattleSituation::testCritical(int player, int target)
     }
 
     bool critical;
-    if (gen().num == 1) {
-        int baseSpeed = PokemonInfo::BaseStats(fpoke(player).id, gen()).baseSpeed() / 2;
-
-        if (tmove(player).critRaise & 1) {
-            baseSpeed *= 8;
-        }
-        /* In RBY, Focus Energy reduces crit by 75% */
-        if (tmove(player).critRaise & 2) {
-            if (gen() <= Pokemon::gen(Gen::Yellow)) {
-                baseSpeed /=4;
-            } else {
-                baseSpeed *= 4;
-            }
-        }
-        int randnum = randint(256);
-
-        critical = randnum < std::min(255, baseSpeed);
-    } else {
-        /* Flail/Reversal don't inflict crits in gen 2 */
-        if (gen().num == 2 && (tmove(player).attack == Move::Flail || tmove(player).attack == Move::Reversal)) {
-            return;
-        }
-
-        int minch;
-        int craise = tmove(player).critRaise;
-
-        if (hasWorkingAbility(player, Ability::SuperLuck)) { /* Super Luck */
-            craise += 1;
-        }
-
-        if (gen() < 6) {
-            switch(craise) {
-            case 0: minch = 3; break;
-            case 1: minch = 6; break;
-            case 2: minch = 12; break;
-            case 3: minch = 16; break;
-            case 4: case 5: minch = 24; break;
-            case 6: default: minch = 48;
-            }
-        } else {
-            switch(craise) {
-            case 0: minch = 3; break;
-            case 1: minch = 6; break;
-            case 2: minch = 24; break;
-            case 3: default: minch = 48;
-            }
-        }
-
-        critical = coinflip(minch, 48);
+    /* Flail/Reversal don't inflict crits in gen 2 */
+    if (gen().num == 2 && (tmove(player).attack == Move::Flail || tmove(player).attack == Move::Reversal)) {
+        return;
     }
+
+    int minch;
+    int craise = tmove(player).critRaise;
+
+    if (hasWorkingAbility(player, Ability::SuperLuck)) { /* Super Luck */
+        craise += 1;
+    }
+
+    if (gen() < 6) {
+        switch(craise) {
+        case 0: minch = 3; break;
+        case 1: minch = 6; break;
+        case 2: minch = 12; break;
+        case 3: minch = 16; break;
+        case 4: case 5: minch = 24; break;
+        case 6: default: minch = 48;
+        }
+    } else {
+        switch(craise) {
+        case 0: minch = 3; break;
+        case 1: minch = 6; break;
+        case 2: minch = 24; break;
+        case 3: default: minch = 48;
+        }
+    }
+
+    critical = coinflip(minch, 48);
 
     if (critical) {
         turnMem(player).add(TM::CriticalHit);
@@ -1369,7 +1335,7 @@ bool BattleSituation::testStatus(int player)
     }
 
     if (poke(player).status() == Pokemon::Asleep) {
-        if (poke(player).statusCount() > (gen().num == 1 ? 1 : 0)) {
+        if (poke(player).statusCount() > 0) {
             //Early bird
             poke(player).statusCount() -= 1 + hasWorkingAbility(player, Ability::EarlyBird);
             notify(All, StatusMessage, player, qint8(FeelAsleep));
@@ -1379,10 +1345,6 @@ bool BattleSituation::testStatus(int player)
         } else {
             healStatus(player, Pokemon::Asleep);
             notify(All, StatusMessage, player, qint8(FreeAsleep));
-
-            /* In gen 1, pokemon take a full turn to wake up */
-            if (gen().num == 1)
-                return false;
         }
     }
     if (poke(player).status() == Pokemon::Frozen)
@@ -2183,11 +2145,6 @@ void BattleSituation::calculateTypeModStab(int orPlayer, int orTarget)
     QVector<int> typePok = getTypes(player);
 
     int typemod = 0;
-
-    // Counter hits regardless of type matchups in Gen 1.
-    if (gen().num == 1 && tmove(player).attack == Move::Counter) {
-        goto end;
-    }
 
     foreach(int type, attackTypes) {
         if (type == Type::Ground && hasFlyingEffect(target) && tmove(player).attack != Move::ThousandArrows) {
@@ -3282,15 +3239,13 @@ int BattleSituation::calculateDamage(int p, int t)
     if (cat == Move::Physical) {
         attack = getStat(p, Attack);
         def = getStat(t, Defense);
+    } else if (attackused == Move::Psyshock || attackused == Move::Psystrike || attackused == Move::SecretSword) {
+        attack = getStat(p, SpAttack);
+        def = getStat(t, Defense);
     } else {
         attack = getStat(p, SpAttack);
-        if(gen().num == 1) {
-            def = getStat(t, SpAttack);
-        } else {
-            def = getStat(t, (attackused == Move::Psyshock || attackused == Move::Psystrike || attackused == Move::SecretSword) ? Defense : SpDefense);
-        }
+        def = getStat(t, SpDefense);
     }
-
 
     /* Used by Pledges to use a special attack, the sum of both */
     if (move.contains("AttackStat")) {
@@ -3310,15 +3265,11 @@ int BattleSituation::calculateDamage(int p, int t)
 
     int stab = turnMem(p).stab;
     int typemod = turnMem(p).typeMod;
-    int randnum;
-    if (gen().num == 1) {
-        randnum = randint(38) + 217;
-    } else {
-        randnum = randint(16) + 85;
-    }
+    int randnum = randint(16) + 85;
     //Spit Up
-    if (attackused == Move::SpitUp) randnum = 100;
-    else if (gen().num == 2 && (attackused == Move::Flail || attackused == Move::Reversal)) randnum = 100;
+    if (attackused == Move::SpitUp && gen().num == 3) {
+        randnum = 100;
+    }
 
     int ch;
     if (gen() <= 5) {
@@ -3410,21 +3361,13 @@ int BattleSituation::calculateDamage(int p, int t)
     }
 
     power = std::min(power, 65535);
-    int damage;
-    if (gen().num == 1) {
-        damage = ((std::min(((level * ch/4 * 2 / 5) + 2) * power, 65535) *
-                   attack / def) / 50) + 2;
-    } else {
-        damage = ((std::min(((level * 2 / 5) + 2) * power, 65535) *
+    int damage = ((std::min(((level * 2 / 5) + 2) * power, 65535) *
                    attack / 50) / def);
-    }
     //Guts, burn
-    if (gen() != 2 || !crit || !turnMemory(p).value("CritIgnoresAll").toBool()) {
-        damage = damage / (
-                    ((poke.status() == Pokemon::Burnt || turnMemory(p).contains("WasBurned")) && cat == Move::Physical && !hasWorkingAbility(p,Ability::Guts)
-                     && !(gen() >= 6 && attackused == Move::Facade))
-                    ? 2 : 1);
-    }
+    damage = damage / (
+                ((poke.status() == Pokemon::Burnt || turnMemory(p).contains("WasBurned")) && cat == Move::Physical && !hasWorkingAbility(p,Ability::Guts)
+                 && !(gen() >= 6 && attackused == Move::Facade))
+                ? 2 : 1);
 
     if (std::abs(terrain) == Type::Fairy && type == Type::Dragon && !isFlying(oppPlayer)) {
         damage /= 2;
@@ -3435,8 +3378,8 @@ int BattleSituation::calculateDamage(int p, int t)
     }
 
     /* Light screen / Reflect */
-    if ( (!crit || (gen().num == 2 && !turnMemory(p).value("CritIgnoresAll").toBool()) ) && !hasWorkingAbility(p, Ability::Infiltrator) &&
-         (teamMemory(this->player(t)).value("Barrier" + QString::number(cat) + "Count").toInt() > 0 || pokeMemory(t).value("Barrier" + QString::number(cat) + "Count").toInt() > 0)) {
+    if (!crit && !hasWorkingAbility(p, Ability::Infiltrator)
+            && teamMemory(this->player(t)).value("Barrier" + QString::number(cat) + "Count").toInt() > 0) {
         if (!multiples()) {
             damage /= 2;
             finalmod /= 2;
@@ -3490,60 +3433,44 @@ int BattleSituation::calculateDamage(int p, int t)
         damage = damage * 3 / 2;
     }
 
-    if (gen().num == 1) { // Gen 1 has no items and crits are already factored in.
-        damage = (damage * stab/2);
-        while (typemod > 0) {
-            damage *= 2;
-            typemod--;
-        }
-        while (typemod < 0) {
-            damage /= 2;
-            typemod++;
-        }
-        damage = (damage * randnum) / 255;
-    } else {
-        damage = (damage+2)*ch/4;
-        move.remove("ItemMod2Modifier");
-        callieffects(p,t,"Mod2Modifier");
-        damage = damage*(10+move["ItemMod2Modifier"].toInt())/10/*Mod2*/;
-        damage = damage *randnum/100*stab/2;
-        finalmod = finalmod*(10+move["ItemMod2Modifier"].toInt())/10;
+    damage = (damage+2)*ch/4;
+    move.remove("ItemMod2Modifier");
+    callieffects(p,t,"Mod2Modifier");
+    damage = damage*(10+move["ItemMod2Modifier"].toInt())/10/*Mod2*/;
+    damage = damage *randnum/100*stab/2;
+    finalmod = finalmod*(10+move["ItemMod2Modifier"].toInt())/10;
 
-        while (typemod > 0) {
-            damage *= 2;
-            typemod--;
-        }
-        while (typemod < 0) {
-            damage /= 2;
-            typemod++;
-        }
+    while (typemod > 0) {
+        damage *= 2;
+        typemod--;
+    }
+    while (typemod < 0) {
+        damage /= 2;
+        typemod++;
+    }
 
-        /* Mod 3 */
-        // FILTER / SOLID ROCK
-        if (turnMem(p).typeMod > 0 && (hasWorkingAbility(t,Ability::Filter) || hasWorkingAbility(t,Ability::SolidRock))) {
-            damage = damage * 3 / 4;
-            finalmod = finalmod * 3 / 4;
-        }
+    /* Mod 3 */
+    // FILTER / SOLID ROCK
+    if (turnMem(p).typeMod > 0 && (hasWorkingAbility(t,Ability::Filter) || hasWorkingAbility(t,Ability::SolidRock))) {
+        damage = damage * 3 / 4;
+        finalmod = finalmod * 3 / 4;
+    }
 
-        /* Expert belt */
-        if (turnMem(p).typeMod > 0 && hasWorkingItem(p, Item::ExpertBelt)) {
-            damage = damage *6/5;
-            finalmod = finalmod *6/5;
-        }
+    /* Expert belt */
+    if (turnMem(p).typeMod > 0 && hasWorkingItem(p, Item::ExpertBelt)) {
+        damage = damage *6/5;
+        finalmod = finalmod *6/5;
+    }
 
-        move.remove("Mod3Berry");
+    move.remove("Mod3Berry");
 
-        /* Berries of the foe */
-        callieffects(t, p, "Mod3Items");
+    /* Berries of the foe */
+    callieffects(t, p, "Mod3Items");
 
-        int berrymod = turnMemory(p).value("Mod3Berry").toInt();
-        if (berrymod != 0) {
-            damage = damage * (10+berrymod)/10;
-            finalmod = finalmod * (10+berrymod)/10;
-        }
-
-        if (gen().num == 2)
-            damage += 1;
+    int berrymod = turnMemory(p).value("Mod3Berry").toInt();
+    if (berrymod != 0) {
+        damage = damage * (10+berrymod)/10;
+        finalmod = finalmod * (10+berrymod)/10;
     }
 
     turnMemory(t)["FinalModifier"] = finalmod;
@@ -4352,8 +4279,6 @@ PokeFraction BattleSituation::getStatBoost(int player, int stat)
                 } else if ((stat == Defense || stat == SpDefense) && boost > 0) {
                     boost = 0;
                 }
-            } else if (gen().num == 1){
-                boost = 0;
             } else if (gen().num == 2 && turnMemory(attacker).value("CritIgnoresAll").toBool()) {
                 boost = 0;
             }

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -572,9 +572,9 @@ void BattleSituation::endTurnPoison(int player)
     } else if (!hasWorkingAbility(player, Ability::MagicGuard)) {
         notify(All, StatusMessage, player, qint8(HurtPoison));
 
-        if (poke(player).statusCount() == 0)
+        if (poke(player).statusCount() == 0) {
             inflictDamage(player, poke(player).totalLifePoints() / 8, player);
-        else {
+        } else {
             inflictDamage(player, poke(player).totalLifePoints() * (16 - poke(player).statusCount()) / 16, player);
             //poke(player).statusCount() = std::max(1, poke(player).statusCount() - 1); //Already being applied earlier.
         }

--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -799,18 +799,18 @@ bool BattleRBY::loseStatMod(int player, int stat, int malus, int attacker, bool 
     if (boost > -6) {
         notify(All, StatChange, player, qint8(stat), qint8(-malus), !tell);
         changeStatMod(player, stat, std::max(boost-malus, -6));
+
+        if (stat < Accuracy) {
+            fpoke(player).stats[stat] = getBoostedStat(player, stat);
+        }
+
+        if (poke(player).status() == Pokemon::Burnt) {
+            fpoke(player).stats[Attack] = std::max(fpoke(player).stats[Attack] / 2, 1);
+        } else if (poke(player).status() == Pokemon::Paralysed) {
+            fpoke(player).stats[Speed] = std::max(fpoke(player).stats[Speed] / 4, 1);
+        }
     } else {
         notify(All, CappedStat, player, qint8(stat), false);
-    }
-
-    if (stat < Accuracy) {
-        fpoke(player).stats[stat] = getBoostedStat(player, stat);
-    }
-
-    if (poke(player).status() == Pokemon::Burnt) {
-        fpoke(player).stats[Attack] = std::max(fpoke(player).stats[Attack] / 2, 1);
-    } else if (poke(player).status() == Pokemon::Paralysed) {
-        fpoke(player).stats[Speed] = std::max(fpoke(player).stats[Speed] / 4, 1);
     }
 
     return true;
@@ -823,24 +823,24 @@ bool BattleRBY::gainStatMod(int player, int stat, int bonus, int, bool tell)
     if (boost < 6 && (getStat(player, stat) < 999 || stat == Evasion)) {
         notify(All, StatChange, player, qint8(stat), qint8(bonus), !tell);
         changeStatMod(player, stat, std::min(boost+bonus, 6));
-    } else {
-        notify(All, CappedStat, player, qint8(stat), true);
-    }
 
-    if (stat < Accuracy) {
-        fpoke(player).stats[stat] = getBoostedStat(player, stat);
-    }
+        if (stat < Accuracy) {
+            fpoke(player).stats[stat] = getBoostedStat(player, stat);
+        }
 
-    // RBY Doubles and Triples are dumb.
-    // Actually they don't exist, but this is just in case.
-    for (int i = 0; i < numberOfSlots(); i++) {
-        if (i != player) {
-            if (poke(i).status() == Pokemon::Burnt) {
-                fpoke(i).stats[Attack] = std::max(fpoke(i).stats[Attack] / 2, 1);
-            } else if (poke(i).status() == Pokemon::Paralysed) {
-                fpoke(i).stats[Speed] = std::max(fpoke(i).stats[Speed] / 4, 1);
+        // RBY Doubles and Triples are dumb.
+        // Actually they don't exist, but this is just in case.
+        for (int i = 0; i < numberOfSlots(); i++) {
+            if (i != player) {
+                if (poke(i).status() == Pokemon::Burnt) {
+                    fpoke(i).stats[Attack] = std::max(fpoke(i).stats[Attack] / 2, 1);
+                } else if (poke(i).status() == Pokemon::Paralysed) {
+                    fpoke(i).stats[Speed] = std::max(fpoke(i).stats[Speed] / 4, 1);
+                }
             }
         }
+    } else {
+        notify(All, CappedStat, player, qint8(stat), true);
     }
 
     return true;


### PR DESCRIPTION
http://pokemon-online.eu/threads/gen-1-speed-drop-reapplication-after-paralysis-too-broad.33289/

This fixes the bug mentioned in the link.

I've also removed gen 1 code from battle.cpp, and gen 2 code from certain sections of calculateDamage where appropriate (gen 2 damage calculation is all in its own if statement). Anything major/slightly complicated which was changed was tested to be working (Light Screen, status, etc). Most things were relatively simple though.

Spit Up shouldn't be non-variable past gen 3 as far as I know. I've only seen this referenced for gen 3 on UPC so I've changed this as well.