### PR TITLE
Fix sound settings + set/edit some default values

### DIFF
--- a/src/Teambuilder/basebattlewindow.cpp
+++ b/src/Teambuilder/basebattlewindow.cpp
@@ -253,7 +253,7 @@ void BaseBattleWindow::musicPlayStop()
 #endif
 
     if (musicPlayed()) {
-        playBattleMusic() = s.value("BattleAudio/PlayMusic").toBool();
+        playBattleMusic() = true;
     }
 
     if (!playBattleMusic()) {
@@ -310,7 +310,7 @@ void BaseBattleWindow::criesPlayStop()
 #endif
 
     if (criesPlayed()) {
-        playBattleCries() = s.value("BattleAudio/PlaySounds").toBool();
+        playBattleCries() = true;
     }
 }
 

--- a/src/Teambuilder/mainwindow.cpp
+++ b/src/Teambuilder/mainwindow.cpp
@@ -41,11 +41,11 @@ static void setDefaultValues()
     QSettings s;
     /* initializing the default init values if not there */
     setDefaultValue(s, "Themes/Current", "Themes/Classic/");
-    setDefaultValue(s, "BattleAudio/CryVolume", 100);
-    setDefaultValue(s, "BattleAudio/MusicVolume", 100);
+    setDefaultValue(s, "BattleAudio/CryVolume", 80);
+    setDefaultValue(s, "BattleAudio/MusicVolume", 80);
     setDefaultValue(s, "BattleAudio/MusicDirectory", "Music/Battle/");
     setDefaultValue(s, "BattleAudio/PlayMusic", false);
-    setDefaultValue(s, "BattleAudio/PlaySounds", false);
+    setDefaultValue(s, "BattleAudio/PlaySounds", true);
     setDefaultValue(s, "Profile/Path", appDataPath("Profiles", true));
     setDefaultValue(s, "Profile/Current", appDataPath("Profiles", false));
 
@@ -77,6 +77,7 @@ static void setDefaultValues()
     setDefaultValue(s, "Client/ShowTimestamps", true);
     setDefaultValue(s, "Client/DisplayTIs", true);
     setDefaultValue(s, "Client/ShowExitWarning", true);
+    setDefaultValue(s, "Client/Client/HideAnnouncement", false);
     setDefaultValue(s, "PlayerEvents/ShowIdle", false);
     setDefaultValue(s, "PlayerEvents/ShowBattle", false);
     setDefaultValue(s, "PlayerEvents/ShowChannel", false);


### PR DESCRIPTION
1. Now the settings in the sound configuration are default values for the battle settings, so when you have turned off Music/Cries in the sound configuration, you can still change them now during a battle (didn't work before).
2. Added default value for "Hide Announcement banner" (off)
3. Change default value for "Play Pokemon Cries" (now on)
4. Change default values for Music/Cry Volume (from 100 to 80, it was way too loud IMO)