### PR TITLE
Fix Stadium crit chance (tests needed)

### DIFF
--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -2088,7 +2088,7 @@ void BattleBase::testCritical(int player, int target)
             else ch = ch >> 1; // only Focus Energy
         }
 
-        int randnum = randint(255) + 1; // randint [1; 256]
+        int randnum = randint(256) + 1; // randint [1; 256]
         critical = randnum < std::min(255, ch); // highest possible crit chance is 255/256
     }
 

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -2046,28 +2046,51 @@ int BattleBase::repeatNum(int player)
 
 void BattleBase::testCritical(int player, int target)
 {
-    (void) target;
-
-    /* In RBY, Focus Energy reduces crit by 75%; in statium, it's * 4 */
-    int up (1), down(1);
-    if (tmove(player).critRaise & 1) {
-        up *= 8;
-    }
-    if (tmove(player).critRaise & 2) {
-        if (gen() == Gen::RedBlue || gen() == Gen::Yellow) {
-            down = 4;
-        } else {
-            up *= 4;
-        }
-    }
-    PokeFraction critChance(up, down);
-    int randnum = randint(512);
     int baseSpeed = PokemonInfo::BaseStats(fpoke(player).id, gen()).baseSpeed();
     //Transformed Pokemon use the original form's base speed.
     if (pokeMemory(slot(player)).contains("PreTransformPoke")) {
         baseSpeed = PokemonInfo::BaseStats(PokemonInfo::Number(pokeMemory(slot(player)).value("PreTransformPoke").toString()), gen()).baseSpeed();;
     }
-    bool critical = randnum < std::min(510, baseSpeed * critChance);
+
+    bool critical = false;
+
+    (void) target;
+
+    if (gen() == Gen::RedBlue || gen() == Gen::Yellow) {
+
+        // In RBY, Focus Energy reduces crit by 75%
+        int up (1), down(1);
+        if (tmove(player).critRaise & 1) {
+            up *= 8;
+        }
+        if (tmove(player).critRaise & 2) {
+                down = 4;
+        }
+
+        PokeFraction critChance(up, down);
+        int randnum = randint(512);
+
+        critical = randnum < std::min(510, baseSpeed * critChance);
+
+    }
+
+    else if (gen() == Gen::Stadium) {
+        int ch = (baseSpeed + 76) >> 2;
+
+        if (tmove(player).critRaise & 1) // Move with high crit ratio
+            ch = ch << 1 << 2;
+
+        if (tmove(player).critRaise & 2) { // Focus Energy
+            ch = (ch << 2) + 160;
+
+            if (tmove(player).critRaise & 1) // Focus Energy + high crit ratio
+                ch = ch << 2;
+            else ch = ch >> 1; // only Focus Energy
+        }
+
+        int randnum = randint(255) + 1; // randint [1; 256]
+        critical = randnum < std::min(255, ch); // highest possible crit chance is 255/256
+    }
 
     if (critical) {
         turnMem(player).add(TM::CriticalHit);

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -2076,19 +2076,16 @@ void BattleBase::testCritical(int player, int target)
 
     else if (gen() == Gen::Stadium) {
         int ch = (baseSpeed + 76) >> 2;
-
-        if (tmove(player).critRaise & 1) // Move with high crit ratio
-            ch = ch << 1 << 2;
-
-        if (tmove(player).critRaise & 2) { // Focus Energy
+ 
+        if (tmove(player).critRaise & 2) // Focus Energy
             ch = (ch << 2) + 160;
-
-            if (tmove(player).critRaise & 1) // Focus Energy + high crit ratio
-                ch = ch << 2;
-            else ch = ch >> 1; // only Focus Energy
-        }
-
-        int randnum = randint(256) + 1; // randint [1; 256]
+        else ch = ch << 1;
+ 
+        if (tmove(player).critRaise & 1) // Move with high crit ratio
+            ch = ch << 2;
+        else ch = ch >> 1;
+ 
+        int randnum = randint(256); // randint [0; 255]
         critical = randnum < std::min(255, ch); // highest possible crit chance is 255/256
     }
 


### PR DESCRIPTION
It looks a bit more complicated than it actually is.

Formula:
- for normal crit chance: (baseSpeed + 76) >> 2
- with Focus Energy: ((baseSpeed + 76) >> 2 << 2 + 160) >> 1
- move with high crit ratio: (baseSpeed + 76) >> 2 << 1 << 2
- with Focus Energy AND move with high crit ratio: ((baseSpeed + 76) >> 2 << 2 + 160) << 2

I hope that I placed the parenthesis correctly.