### PR TITLE
Fix Protect failure chance in Gen 6

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -710,7 +710,7 @@ struct MMDetect : public MM
             int x = 1 << (std::min(protectCount, 3));
 
             return (b.randint() & (x-1)) == 0;
-        } else {
+        } else if (b.gen() <= 5) {
             int x = 1 << (std::min(protectCount, 8));
 
             if (x >= 256) {
@@ -718,6 +718,9 @@ struct MMDetect : public MM
             } else {
                 return (b.randint() & (x-1)) == 0;
             }
+        } else {            
+            double x = 100.0 / (pow(3.0, std::min(protectCount, 6)));
+            return b.coinflip(x, 100.0);
         }
     }
 


### PR DESCRIPTION
http://pokemon-online.eu/threads/protect-implemented-incorrectly.32868/
I did some quick tests:
protectCount = 1 -> x = 33.33
protectCount = 2 -> x = 11.11
protectCount = 3 -> x = 3.07
...

coinflip(x,100.0) -> probability (x/100)

