### PR TITLE
Fix Bide and Wrap/Bind/... mechanics in Stadium

### DIFF
--- a/src/BattleServer/rbymoves.cpp
+++ b/src/BattleServer/rbymoves.cpp
@@ -181,8 +181,9 @@ struct RBYBind : public MM
     }
 
     static void ts(int s, int, BS &b) {
-        /* If the opponent was koed, reset everything */
         int t = b.opponent(s);
+        /* If the opponent was koed, reset everything */
+        if (!poke(b,t).contains("Bound")) {
             poke(b,s).remove("BindCount");
         }
         if (poke(b,s).value("LastBind").toInt() == b.turn()-1 && poke(b,s).value("BindCount").toInt() > 0) {


### PR DESCRIPTION
Bide fails against targets in invulnerable states (Dig, Fly). Tested and
seems to work.
Bind/Wrap etc. stop when target switches out. Only did a quick test,
hopefully doesn't break anything.