### PR TITLE
Fix RBY stat change bug in Stadium

### DIFF
--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -113,11 +113,13 @@ void BattleRBY::sendPoke(int slot, int pok, bool silent)
     // Give new values to what needed
     fpoke(slot).init(p, gen());
 
-    if (p.status() == Pokemon::Paralysed) {
-        fpoke(slot).stats[Speed] = std::max(fpoke(slot).stats[Speed] / 4, 1);
-    }
-    if (p.status() == Pokemon::Burnt) {
-        fpoke(slot).stats[Attack] = std::max(fpoke(slot).stats[Attack] / 2, 1);
+    if (!isStadium()) {
+        if (p.status() == Pokemon::Paralysed) {
+            fpoke(slot).stats[Speed] = std::max(fpoke(slot).stats[Speed] / 4, 1);
+        }
+        if (p.status() == Pokemon::Burnt) {
+            fpoke(slot).stats[Attack] = std::max(fpoke(slot).stats[Attack] / 2, 1);
+        }
     }
     if (p.status() != Pokemon::Asleep) {
         p.statusCount() = 0;
@@ -804,10 +806,12 @@ bool BattleRBY::loseStatMod(int player, int stat, int malus, int attacker, bool 
             fpoke(player).stats[stat] = getBoostedStat(player, stat);
         }
 
-        if (poke(player).status() == Pokemon::Burnt) {
-            fpoke(player).stats[Attack] = std::max(fpoke(player).stats[Attack] / 2, 1);
-        } else if (poke(player).status() == Pokemon::Paralysed) {
-            fpoke(player).stats[Speed] = std::max(fpoke(player).stats[Speed] / 4, 1);
+        if (!isStadium()) {
+            if (poke(player).status() == Pokemon::Burnt) {
+                fpoke(player).stats[Attack] = std::max(fpoke(player).stats[Attack] / 2, 1);
+            } else if (poke(player).status() == Pokemon::Paralysed) {
+                fpoke(player).stats[Speed] = std::max(fpoke(player).stats[Speed] / 4, 1);
+            }
         }
     } else {
         notify(All, CappedStat, player, qint8(stat), false);
@@ -830,12 +834,14 @@ bool BattleRBY::gainStatMod(int player, int stat, int bonus, int, bool tell)
 
         // RBY Doubles and Triples are dumb.
         // Actually they don't exist, but this is just in case.
-        for (int i = 0; i < numberOfSlots(); i++) {
-            if (i != player) {
-                if (poke(i).status() == Pokemon::Burnt) {
-                    fpoke(i).stats[Attack] = std::max(fpoke(i).stats[Attack] / 2, 1);
-                } else if (poke(i).status() == Pokemon::Paralysed) {
-                    fpoke(i).stats[Speed] = std::max(fpoke(i).stats[Speed] / 4, 1);
+        if (!isStadium()) {
+            for (int i = 0; i < numberOfSlots(); i++) {
+                if (i != player) {
+                    if (poke(i).status() == Pokemon::Burnt) {
+                        fpoke(i).stats[Attack] = std::max(fpoke(i).stats[Attack] / 2, 1);
+                    } else if (poke(i).status() == Pokemon::Paralysed) {
+                        fpoke(i).stats[Speed] = std::max(fpoke(i).stats[Speed] / 4, 1);
+                    }
                 }
             }
         }

--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -113,13 +113,11 @@ void BattleRBY::sendPoke(int slot, int pok, bool silent)
     // Give new values to what needed
     fpoke(slot).init(p, gen());
 
-    if (!isStadium()) {
-        if (p.status() == Pokemon::Paralysed) {
-            fpoke(slot).stats[Speed] = std::max(fpoke(slot).stats[Speed] / 4, 1);
-        }
-        if (p.status() == Pokemon::Burnt) {
-            fpoke(slot).stats[Attack] = std::max(fpoke(slot).stats[Attack] / 2, 1);
-        }
+    if (p.status() == Pokemon::Paralysed) {
+        fpoke(slot).stats[Speed] = std::max(fpoke(slot).stats[Speed] / 4, 1);
+    }
+    if (p.status() == Pokemon::Burnt) {
+        fpoke(slot).stats[Attack] = std::max(fpoke(slot).stats[Attack] / 2, 1);
     }
     if (p.status() != Pokemon::Asleep) {
         p.statusCount() = 0;


### PR DESCRIPTION
The bug only applies to RBY, not Stadium.
@Sulcata Can you check if I understood the code correctly, because you added this code :v 
This should fix 
     **-Stat-boosting moves do not re-apply stat drops from Burn and Paralysis**
and maybe(?)
    **-Agility does not circumvent Paralysis Speed drop**
from [this post](http://pokemon-online.eu/threads/stadium-checklist.33832/)