### PR TITLE
Fix last damage variable resetting in Stadium

### DIFF
--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -2053,9 +2053,11 @@ void BattleBase::testCritical(int player, int target)
     }
 
     bool critical = false;
+
     (void) target;
 
     if (!isStadium()) {
+
         // In RBY, Focus Energy reduces crit by 75%
         int up (1), down(1);
         if (tmove(player).critRaise & 1) {
@@ -2064,15 +2066,18 @@ void BattleBase::testCritical(int player, int target)
         if (tmove(player).critRaise & 2) {
             if (gen() == Gen::RedBlue || gen() == Gen::Yellow) {
                 down = 4;
-            } else {
-                up *= 4;
             }
+        } else {
+            up *= 4;
         }
 
         PokeFraction critChance(up, down);
         int randnum = randint(512);
+
         critical = randnum < std::min(510, baseSpeed * critChance);
+
     }
+
     else {
         int ch = (baseSpeed + 76) >> 2;
 

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -1805,74 +1805,8 @@ void BattleBase::sendBack(int player, bool silent)
     if (turnMemory(player).contains("PrimalForme")) {
         turnMemory(player).remove("PrimalForme");
     }
-    if (isStadium()) {
-        battleMemory()["LastDamageTakenByAny"] = 0;
-    }
 
     notify(All, SendBack, player, silent);
-}
-
-bool BattleBase::testStatus(int player)
-{
-    if (turnMem(player).contains(TM::HasPassedStatus)) {
-        return true;
-    }
-
-    if (poke(player).status() == Pokemon::Asleep) {
-        if (poke(player).statusCount() > 1) {
-            poke(player).statusCount() -= 1;
-            notify(All, StatusMessage, player, qint8(FeelAsleep));
-
-            return false;
-        } else {
-            healStatus(player, Pokemon::Asleep);
-            notify(All, StatusMessage, player, qint8(FreeAsleep));
-
-            return false;
-        }
-    }
-    if (poke(player).status() == Pokemon::Frozen)
-    {
-        notify(All, StatusMessage, player, qint8(PrevFrozen));
-        return false;
-    }
-
-    if (turnMem(player).contains(TM::Flinched)) {
-        notify(All, Flinch, player);
-
-        return false;
-    }
-    if (isConfused(player) && tmove(player).attack != 0) {
-        if (pokeMemory(player)["ConfusedCount"].toInt() > 0) {
-            inc(pokeMemory(player)["ConfusedCount"], -1);
-
-            notify(All, StatusMessage, player, qint8(FeelConfusion));
-
-            if (coinflip(1, 2)) {
-                pokeMemory(player).remove("PetalDanceCount"); //RBY
-                inflictConfusedDamage(player);
-                return false;
-            }
-        } else {
-            healConfused(player);
-            notify(All, StatusMessage, player, qint8(FreeConfusion));
-        }
-    }
-
-    if (poke(player).status() == Pokemon::Paralysed) {
-        if (coinflip(1, 4)) {
-            pokeMemory(player).remove("PetalDanceCount"); //RBY
-
-            if (isStadium()) {
-                battleMemory()["LastDamageTakenByAny"] = 0;
-            }
-
-            notify(All, StatusMessage, player, qint8(PrevParalysed));
-            return false;
-        }
-    }
-
-    return true;
 }
 
 void BattleBase::healStatus(int player, int status)

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -1805,6 +1805,10 @@ void BattleBase::sendBack(int player, bool silent)
     if (turnMemory(player).contains("PrimalForme")) {
         turnMemory(player).remove("PrimalForme");
     }
+    if (isStadium()) {
+        battleMemory()["LastDamageTakenByAny"] = 0;
+    }
+
     notify(All, SendBack, player, silent);
 }
 
@@ -1858,6 +1862,11 @@ bool BattleBase::testStatus(int player)
     if (poke(player).status() == Pokemon::Paralysed) {
         if (coinflip(1, 4)) {
             pokeMemory(player).remove("PetalDanceCount"); //RBY
+
+            if (isStadium()) {
+                battleMemory()["LastDamageTakenByAny"] = 0;
+            }
+
             notify(All, StatusMessage, player, qint8(PrevParalysed));
             return false;
         }

--- a/src/BattleServer/battlebase.h
+++ b/src/BattleServer/battlebase.h
@@ -444,8 +444,6 @@ public:
     virtual const context &pokeMemory(int slot) const = 0;
     virtual context &turnMemory(int slot) = 0;
     virtual const context &turnMemory(int slot) const = 0;
-    virtual context &battleMemory() = 0;
-    virtual const context &battleMemory() const = 0;
     virtual BasicMoveInfo &tmove(int slot) = 0;
     virtual const BasicMoveInfo &tmove(int slot) const = 0;
 
@@ -470,7 +468,6 @@ public:
     /* if special occurence = true, then it means a move like mimic/copycat/metronome has been used. In that case attack does not
     represent the moveslot but rather than that it represents the move num, plus PP will not be lost */
     virtual void useAttack(int player, int attack, bool specialOccurence = false, bool notify = true) = 0;
-    virtual bool testStatus(int player);
 
     void healStatus(int player, int status);
     bool isConfused(int player);

--- a/src/BattleServer/battlebase.h
+++ b/src/BattleServer/battlebase.h
@@ -468,6 +468,7 @@ public:
     /* if special occurence = true, then it means a move like mimic/copycat/metronome has been used. In that case attack does not
     represent the moveslot but rather than that it represents the move num, plus PP will not be lost */
     virtual void useAttack(int player, int attack, bool specialOccurence = false, bool notify = true) = 0;
+    virtual bool testStatus(int player) = 0;
 
     void healStatus(int player, int status);
     bool isConfused(int player);

--- a/src/BattleServer/battlebase.h
+++ b/src/BattleServer/battlebase.h
@@ -444,6 +444,8 @@ public:
     virtual const context &pokeMemory(int slot) const = 0;
     virtual context &turnMemory(int slot) = 0;
     virtual const context &turnMemory(int slot) const = 0;
+    virtual context &battleMemory() = 0;
+    virtual const context &battleMemory() const = 0;
     virtual BasicMoveInfo &tmove(int slot) = 0;
     virtual const BasicMoveInfo &tmove(int slot) const = 0;
 

--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -644,6 +644,77 @@ void BattleRBY::inflictRecoil(int source, int target)
     }
 }
 
+void BattleRBY::sendBack(int player, bool silent) {
+
+    BattleBase::sendBack(player, silent);
+
+    if (isStadium()) {
+        battleMemory()["LastDamageTakenByAny"] = 0;
+    }
+}
+
+bool BattleRBY::testStatus(int player) {
+    if (turnMem(player).contains(TM::HasPassedStatus)) {
+        return true;
+    }
+
+    if (poke(player).status() == Pokemon::Asleep) {
+        if (poke(player).statusCount() > 1) {
+            poke(player).statusCount() -= 1;
+            notify(All, StatusMessage, player, qint8(FeelAsleep));
+
+            return false;
+        } else {
+            healStatus(player, Pokemon::Asleep);
+            notify(All, StatusMessage, player, qint8(FreeAsleep));
+
+            return false;
+        }
+    }
+    if (poke(player).status() == Pokemon::Frozen)
+    {
+        notify(All, StatusMessage, player, qint8(PrevFrozen));
+        return false;
+    }
+
+    if (turnMem(player).contains(TM::Flinched)) {
+        notify(All, Flinch, player);
+
+        return false;
+    }
+    if (isConfused(player) && tmove(player).attack != 0) {
+        if (pokeMemory(player)["ConfusedCount"].toInt() > 0) {
+            inc(pokeMemory(player)["ConfusedCount"], -1);
+
+            notify(All, StatusMessage, player, qint8(FeelConfusion));
+
+            if (coinflip(1, 2)) {
+                pokeMemory(player).remove("PetalDanceCount");
+                inflictConfusedDamage(player);
+                return false;
+            }
+        } else {
+            healConfused(player);
+            notify(All, StatusMessage, player, qint8(FreeConfusion));
+        }
+    }
+
+    if (poke(player).status() == Pokemon::Paralysed) {
+        if (coinflip(1, 4)) {
+            pokeMemory(player).remove("PetalDanceCount");
+
+            if (isStadium()) {
+                battleMemory()["LastDamageTakenByAny"] = 0;
+            }
+
+            notify(All, StatusMessage, player, qint8(PrevParalysed));
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void BattleRBY::callpeffects(int source, int target, const QString &name)
 {
     if (pokeMemory(source).contains("Effect_" + name)) {

--- a/src/BattleServer/battlerby.h
+++ b/src/BattleServer/battlerby.h
@@ -34,6 +34,8 @@ protected:
     bool testAccuracy(int player, int target, bool silent=false);
     void inflictRecoil(int x, int target);
     bool loseStatMod(int player, int stat, int malus, int attacker, bool tell);
+    void sendBack(int player, bool silent);
+    virtual bool testStatus(int player);
 
     void personalEndTurn(int player);
     void setupMove(int i, int move);

--- a/src/BattleServer/rbymoves.cpp
+++ b/src/BattleServer/rbymoves.cpp
@@ -312,6 +312,11 @@ struct RBYDig : public MM
         poke(b,s)["DigChargeTurn"] = b.turn();
         poke(b,s)["Invulnerable"] = true;
         poke(b,s)["ChargeMove"] = move(b,s);
+
+        if (b.isStadium()) {
+            b.battleMemory()["LastDamageTakenByAny"] = 0;
+        }
+
         b.changeSprite(s, -1);
 
         addFunction(poke(b,s), "TurnSettings", "Dig", &ts);


### PR DESCRIPTION
The variable storing the last damage dealt is properly set to 0 when
needed (after a full paralysis, a switch, a charge turn...) in Stadium.
Did a quick test and seems to work fine