### PR TITLE
Fix Stadium Mimic PP

### DIFF
--- a/src/BattleServer/rbymoves.cpp
+++ b/src/BattleServer/rbymoves.cpp
@@ -726,10 +726,10 @@ struct RBYMimic : public MM
             move = b.move(t, b.randint(4));
         }
         int slot = fpoke(b,s).lastMoveSlot;
-        int pp = b.PP(s, slot);
+        int oldpp = b.PP(s, slot);
         b.changeTempMove(s, slot, move);
         if (b.isStadium()) {
-            b.changePP(s, slot, std::min(pp, 15));
+            b.changePP(s, slot, oldpp);
         }
         b.sendMoveMessage(81,0,s,type(b,s),t,move);
     }

--- a/src/BattleServer/rbymoves.cpp
+++ b/src/BattleServer/rbymoves.cpp
@@ -726,9 +726,10 @@ struct RBYMimic : public MM
             move = b.move(t, b.randint(4));
         }
         int slot = fpoke(b,s).lastMoveSlot;
+        int pp = b.PP(s, slot);
         b.changeTempMove(s, slot, move);
         if (b.isStadium()) {
-            b.changePP(s, slot, 15);
+            b.changePP(s, slot, std::min(pp, 15));
         }
         b.sendMoveMessage(81,0,s,type(b,s),t,move);
     }


### PR DESCRIPTION
Make sure that the PP of Mimic doesn't raise when you use it, switch to
another poke, switch back and use it again.