### PR TITLE
Fix Berries not activating when Infiltrator bypasses Sub

### DIFF
--- a/src/BattleServer/berries.cpp
+++ b/src/BattleServer/berries.cpp
@@ -190,7 +190,7 @@ struct BMAntiSuperEffective : public BM
         if (!b.attacking()) {
             return;
         }
-        if (!b.hasSubstitute(s) && fturn(b,t).typeMod > 0 && tmove(b,t).type == poke(b,s)["ItemArg"].toInt()) {
+        if ((!b.hasSubstitute(s) || b.hasWorkingAbility(t, Ability::Infiltrator)) && fturn(b,t).typeMod > 0 && tmove(b,t).type == poke(b,s)["ItemArg"].toInt()) {
             b.sendBerryMessage(4,s,0,t,b.poke(s).item(),move(b,t));
             b.eatBerry(s,false);
 
@@ -212,7 +212,7 @@ struct BMAntiNormal : public BM
         /* We never want to activate this berry if this is consumed by Bug Bite */
         if (b.gen() >= 4 && !turn(b,s).value("BugBiter").toBool()) {
             /* Normal moves */
-            if (!b.hasSubstitute(s) && tmove(b,t).type == 0) {
+            if ((!b.hasSubstitute(s) || b.hasWorkingAbility(t, Ability::Infiltrator)) && tmove(b,t).type == 0) {
                 b.sendBerryMessage(4,s,0,t,b.poke(s).item(),move(b,t));
                 b.eatBerry(s,false);
 

--- a/src/Teambuilder/Teambuilder/teammenu.cpp
+++ b/src/Teambuilder/Teambuilder/teammenu.cpp
@@ -136,9 +136,7 @@ void TeamMenu::updatePokemons()
     foreach(PokeEdit *p, ui->pokemons) {
         p->setPoke(&team().team().poke(p->property("slot").toInt()));
     }
-    for (int i = 0; i < 6; i++) {
-        ui->pokemonTabs->setTabIcon(i, PokemonInfo::Icon(team().team().poke(i).num(),team().team().poke(i).gender()));
-    }
+    updateTabs();
 }
 
 void TeamMenu::toggleHackmons()


### PR DESCRIPTION
[Fixes this.](http://pokemon-online.eu/threads/infiltrator-dark-attack-ignores-colbur-berry-behind-substitute.34163/#post-470775)
[Here's a screenshot of my test](http://puu.sh/pjZ1y.jpg).
