### PR TITLE
Fix Triple Kick hit message when it only hits once

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1964,7 +1964,9 @@ ppfunction:
                 }
             }
 
-            if (hit) {
+            // Triple Kick has an accuracy check for every attack, so it is possible that it only hits once.
+            // Make sure that the hit message is still shown.
+            if (hit || turnMemory(player).contains("RepeatCount")) {
                 notifyHits(player, hitcount);
             }
 


### PR DESCRIPTION
http://pokemon-online.eu/threads/triple-kick-display-bug.34168/#post-470840
Only Triple Kicks seems to use _turn(b,s)["RepeatCount"]_ , so it shouldn't break anything else (at least I hope so).
Tested and can confirm that it fixes the bug.