### PR TITLE
po:openteambuilder

### DIFF
--- a/src/Teambuilder/channel.cpp
+++ b/src/Teambuilder/channel.cpp
@@ -139,6 +139,8 @@ void Channel::anchorClicked(const QUrl &url)
             client->activateChannel(cname);
         } else if (path == "reconnect") {
             client->reconnect();
+        } else if (path == "openteambuilder") {
+            client->openTeamBuilder();
         } else if (path.leftRef(6) == "watch/") {
             int id = path.mid(6).toInt();
             client->watchBattleRequ(id);


### PR DESCRIPTION
This new po: link could be used for messages where the user is asked to open their teambuilder in order to change any moveset for their team or whatever, as it is even more convenient than the _Open Teambuilder_ button/menu option (besides, a few users have not figured out yet how to open their teambuilder without leaving the server).

The string of the link might be changed to something shorter.