### PR TITLE
Fix Baton Pass + moves that use LastMoveUsed memory (untested)

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -226,6 +226,10 @@ struct MMBatonPass : public MM
             if (b.linked(opp, "Attract"))
                 poke(b, opp).remove("AttractBy");
         }
+        // Remove the last move memomy
+        c.remove("AnyLastMoveUsed");
+        c.remove("LastMoveUsed");
+        c.remove("LastMoveUsedTurn");
 
         QList<int> boosts;
 


### PR DESCRIPTION
At least it makes sense to me, because the new pokemon didn't use any moves yet.
I doubt that something will break because of it.
Should fix http://pokemon-online.eu/threads/34911/
Opinions?