### PR TITLE
Fix Trace

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -1256,21 +1256,32 @@ struct AMThickFat : public AM {
 struct AMTrace : public AM {
     AMTrace() {
         functions["UponSetup"] = &us;
+        functions["UponOpponentSwitchIn"] = &us;
     }
 
     static void us(int s, int, BS &b) {
-        int t = b.randomOpponent(s);
-
-        if (t == - 1)
-            return;
-
-        int ab = b.ability(t);
-        //Multitype
-        if (b.hasWorkingAbility(t, ab) && ab != Ability::Multitype && ab !=  Ability::Trace
-            && !(ab == Ability::Illusion && poke(b,t).contains("IllusionTarget")) && ab != Ability::StanceChange) {
-            b.sendAbMessage(66,0,s,t,0,ab);
-            b.loseAbility(s);
-            b.acquireAbility(s, ab);
+        //Randomly choose among adjacent and valid ability
+        QList<int> opps = b.revs(s);
+        for(int i = 0; i < opps.size(); i++) {
+            if(!b.areAdjacent(s, opps[i])) {
+                opps.removeAt(i);
+                i--;
+            }
+        }
+        while(!opps.empty()) {
+            int i = b.randint(opps.size());
+            int t = opps[i];
+            int ab = b.ability(t);
+            //Multitype
+            if (b.hasWorkingAbility(t, ab) && ab != Ability::Multitype && ab != Ability::Trace && ab != Ability::FlowerGift
+                && !(ab == Ability::Illusion && poke(b,t).contains("IllusionTarget")) && ab != Ability::StanceChange) {
+                b.sendAbMessage(66,0,s,t,0,ab);
+                b.loseAbility(s);
+                b.acquireAbility(s, ab);
+                return;
+            } else {
+                opps.removeAt(i);
+            }
         }
     }
 };

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -992,6 +992,12 @@ void BattleSituation::sendPoke(int slot, int pok, bool silent)
     calleffects(slot, slot, "UponSwitchIn");
     callseffects(slot, slot, "UponSwitchIn");
     callzeffects(player, slot, "UponSwitchIn");
+    if(turn() != 0) {
+        QList<int> opps = revs(slot);
+        foreach(int opp, opps){
+            callaeffects(opp, opp, "UponOpponentSwitchIn");
+        }
+    }
 }
 
 void BattleSituation::callEntryEffects(int player)


### PR DESCRIPTION
Several bug fixes

1. If a Pokemon has Trace (i.e. VoltTurn KO or untraceable ability) the ability should reactivate any time an opposing Pokemon switches in (needs in game test for gen 3/4)
2. Trace doesn't work on Flower Gift
3. In a double/triple battle, Trace should always activate if there is any valid target (instead of giving up after the first random target has an untraceable ability)
4. Trace can't copy the farthest Pokemon in a triple battle