### PR TITLE
Fix ZMove structure

### DIFF
--- a/bin/db/moves/moves.txt
+++ b/bin/db/moves/moves.txt
@@ -692,7 +692,7 @@
 691 Catastropika
 692 Stoked SparkSurfer
 693 Extreme Evoboost
-694 Pulversing Pancake
+694 Pulverizing Pancake
 695 Genesis Supernova
 696 Guardian of Alola
 697 Sinister Arrow Raid

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1609,8 +1609,6 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
         sendItemMessage(68, player);
         if (tmove(player).power > 0) {
             notify(All, UseAttack, player, qint16(ItemInfo::ZCrystalMove(poke(player).item())), false, true);
-            //attack = ItemInfo::ZCrystalMove(poke(player).item());
-            callieffects(player, player, "MoveSettings"); //Z Moves
             zmovenotify = true;
         } else {
             sendItemMessage(68, player, 2, 0, 0, attack);

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -4908,7 +4908,7 @@ void BattleSituation::storeChoice(const BattleChoice &b)
 void BattleSituation::setupMove(int i, int move, bool zmove)
 {
     //ZAttack should be a completely seperate move from the base attack
-    if (zmove && MoveInfo::Power(move, this->gen()) > 0 && !zmoves[player(i)]) {
+    if (zmove && MoveInfo::Power(move, this->gen()) > 0 && !zmoves[player(i)] && canBeZMove(i, move)) {
         int zmove = ItemInfo::ZCrystalMove(this->poke(i).item());
         int power = MoveInfo::ZPower(move, this->gen());;
         if (MoveInfo::isUniqueZMove(zmove)) {

--- a/src/BattleServer/battle.h
+++ b/src/BattleServer/battle.h
@@ -215,7 +215,7 @@ private:
     virtual void notifySituation(int dest);
 
     virtual void storeChoice(const BattleChoice &b);
-    void setupMove(int player, int move);
+    void setupMove(int player, int move, bool zmove = false);
 public:
     std::vector<int> targetList;
     /* Calls the effects of source reacting to name */

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -1607,7 +1607,7 @@ void BattleBase::setupChoices()
     for (int i = 0; i < numberOfSlots(); i++) {
         if (!koed(i) && !turnMem(i).contains(TurnMemory::NoChoice) && !turnMem(i).contains(TurnMemory::KeepAttack) && choice(i).attackingChoice()) {
             if (!options[i].struggle())
-                setupMove(i, move(i,choice(i).pokeSlot()));
+                setupMove(i, move(i,choice(i).pokeSlot()), choice(i).zmove());
             else
                 setupMove(i, Move::Struggle);
         }

--- a/src/BattleServer/battlebase.h
+++ b/src/BattleServer/battlebase.h
@@ -297,7 +297,7 @@ protected:
     virtual BattleChoices createChoice(int slot) = 0;
 
     void setupChoices() ;
-    virtual void setupMove(int i, int move) = 0;
+    virtual void setupMove(int i, int move, bool zmove = false) = 0;
 
     virtual void analyzeChoices() = 0;
 

--- a/src/BattleServer/battlerby.cpp
+++ b/src/BattleServer/battlerby.cpp
@@ -758,7 +758,7 @@ void BattleRBY::calleffects(int source, int target, const QString &name)
     }
 }
 
-void BattleRBY::setupMove(int i, int move)
+void BattleRBY::setupMove(int i, int move, bool zmove)
 {
     RBYMoveEffect::setup(move,i,0,*this);
 }

--- a/src/BattleServer/battlerby.h
+++ b/src/BattleServer/battlerby.h
@@ -38,7 +38,7 @@ protected:
     virtual bool testStatus(int player);
 
     void personalEndTurn(int player);
-    void setupMove(int i, int move);
+    void setupMove(int i, int move, bool zmove = false);
 private:
     BattleChoice choices[2];
 

--- a/src/BattleServer/items.cpp
+++ b/src/BattleServer/items.cpp
@@ -1138,53 +1138,6 @@ struct IMPrimalOrb : public IM {
     }
 };
 
-struct IMZCrystal : public IM {
-    IMZCrystal() {
-        functions["MoveSettings"] = &ms;
-    }
-
-    static void ms (int s, int, BS &b) {
-        if (tmove(b,s).power > 0) {
-            tmove(b,s).power = tmove(b,s).zpower;
-
-            int zmove = ItemInfo::ZCrystalMove(b.poke(s).item());
-            if (MoveInfo::isUniqueZMove(zmove)) {
-                tmove(b,s).power = MoveInfo::Power(zmove, b.gen());
-            }
-            //b.debug(QString("Debug: Power = %1").arg(tmove(b,s).power));
-
-            /* Sigh... only way to get it working properly... */
-            tmove(b,s).accuracy = 100;
-            tmove(b,s).flags = MoveInfo::Flags(zmove, b.gen());
-            tmove(b,s).classification = Move::StandardMove;
-            tmove(b,s).boostOfStat = 0;
-            tmove(b,s).critRaise = 0;
-            tmove(b,s).flinchRate = 0;
-            tmove(b,s).healing = 0;
-            tmove(b,s).priority = 0;
-            tmove(b,s).maxTurns = 0;
-            tmove(b,s).minTurns = 0;
-            tmove(b,s).rate = 0;
-            tmove(b,s).recoil = 0;
-            tmove(b,s).repeatMax = 0;
-            tmove(b,s).repeatMin = 0;
-            tmove(b,s).status = 0;
-            tmove(b,s).statAffected = 0;
-            tmove(b,s).rateOfStat = 0;
-
-            if (zmove == Move::StokedSparkSurfer) {
-                tmove(b,s).classification = Move::OffensiveStatusInducingMove;
-                tmove(b,s).status = MoveInfo::Status(zmove, b.gen());
-                tmove(b,s).rate = MoveInfo::EffectRate(zmove, b.gen());
-            } else if (zmove == Move::_10_000_000VoltThunderBolt) {
-                tmove(b,s).critRaise = MoveInfo::CriticalRaise(zmove, b.gen());
-            }
-            //TODO: Test Evoboost + Guardian of Alola
-            //TODO: Code Psychic terrain effect for Genesis Supernova
-        }
-    }
-};
-
 struct IMSeeds : public IM {
     IMSeeds() {
         functions["UponSetup"] = &us;
@@ -1251,7 +1204,7 @@ void ItemEffect::init()
     //66 Mega stones
     REGISTER_ITEM(67, PrimalOrb);
     REGISTER_ITEM(68, MemoryChip);
-    REGISTER_ITEM(69, ZCrystal);
+    //REGISTER_ITEM(69, ZCrystal);
     REGISTER_ITEM(70, Seeds);
     //71 Adrenaline orb message
     //72 Protective pads message

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -8037,6 +8037,19 @@ struct MMSpeedSwap : public MM
     }
 };
 
+struct MMWaterShuriken : public MM
+{
+    MMWaterShuriken() {
+        functions["BasePowerModifier"] = &bpm;
+    }
+
+    static void bpm(int s, int, BS &b) {
+        if (b.poke(s).num() == Pokemon::Ash_Greninja) {
+            b.chainBp(s, 0x1800);
+        }
+    }
+};
+
 struct MMZBoost : public MM
 {
     MMZBoost() {
@@ -8157,6 +8170,7 @@ struct MMZHealSwitch : public MM
 
 struct MMZSupernova : public MM
 {
+    //TODO: Code Psychic terrain effect for Genesis Supernova
     MMZSupernova() {
         functions["AfterAttackFinished"] = &zm;
     }
@@ -8171,6 +8185,7 @@ struct MMZSupernova : public MM
 
 struct MMZAlola : public MM
 {
+    //TODO: Test Evoboost + Guardian of Alola
     MMZAlola() {
         functions["CustomAttackingDamage"] = &uas;
     }
@@ -8179,19 +8194,6 @@ struct MMZAlola : public MM
         turn(b,s)["CustomDamage"] = b.poke(t).lifePoints()* 3 / 4;
         if (turn(b,t).value("ZMoveProtected").toBool()) {
             turn(b,s)["CustomDamage"] = turn(b,s)["CustomDamage"].toInt() * 3 / 4;
-        }
-    }
-};
-
-struct MMWaterShuriken : public MM
-{
-    MMWaterShuriken() {
-        functions["BasePowerModifier"] = &bpm;
-    }
-
-    static void bpm(int s, int, BS &b) {
-        if (b.poke(s).num() == Pokemon::Ash_Greninja) {
-            b.chainBp(s, 0x1800);
         }
     }
 };

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -8170,14 +8170,13 @@ struct MMZHealSwitch : public MM
 
 struct MMZSupernova : public MM
 {
-    //TODO: Code Psychic terrain effect for Genesis Supernova
     MMZSupernova() {
         functions["AfterAttackFinished"] = &zm;
     }
 
     static void zm(int, int, BS &b) {
         if(b.terrain != BS::PsychicTerrain) {
-            //No terrain extender cause you can only hold 1 item!
+            //TODO: terrain extender because hackmons
             b.coverField(BS::PsychicTerrain, 5);
         }
     }


### PR DESCRIPTION
Moved where a move becomes the zmove so that when the base move is something like UTurn or Feint the  zmove doesn't switch out/break protection/etc. Moved where the zmoves used is set so that if a Pokemon faints before attacking the player can still use a zmove later. Moved Water Shuriken because ocd.