### PR TITLE
Bypasses substitute for attack effects

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -2011,6 +2011,8 @@ ppfunction:
             int hitcount = 0;
             bool hitting = false;
             bool noDamage = false;
+            bool sub = false;
+            
             for (repeatCount() = 0; repeatCount() < num && !koed(target) && (repeatCount()==0 || !koed(player)); repeatCount()+=1) {
                 clearAtk();
                 clearBp();
@@ -2018,7 +2020,7 @@ ppfunction:
                 noDamage = turnMemory(target).contains(QString("BlockDamageOnly%1").arg(attackCount()));
 
                 fpoke(target).remove(BasicPokeInfo::HadSubstitute);
-                bool sub = hasSubstitute(target) && !canBypassSub(player);
+                sub = hasSubstitute(target) && !canBypassSub(player);
                 if (sub) {
                     fpoke(target).add(BasicPokeInfo::HadSubstitute);
                 }

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -2018,7 +2018,7 @@ ppfunction:
                 noDamage = turnMemory(target).contains(QString("BlockDamageOnly%1").arg(attackCount()));
 
                 fpoke(target).remove(BasicPokeInfo::HadSubstitute);
-                bool sub = hasSubstitute(target) && !canBypassSub(player, target);
+                bool sub = hasSubstitute(target) && !canBypassSub(player);
                 if (sub) {
                     fpoke(target).add(BasicPokeInfo::HadSubstitute);
                 }

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -2018,7 +2018,7 @@ ppfunction:
                 noDamage = turnMemory(target).contains(QString("BlockDamageOnly%1").arg(attackCount()));
 
                 fpoke(target).remove(BasicPokeInfo::HadSubstitute);
-                bool sub = hasSubstitute(target);
+                bool sub = hasSubstitute(target) && !canBypassSub(player, target);
                 if (sub) {
                     fpoke(target).add(BasicPokeInfo::HadSubstitute);
                 }
@@ -2064,7 +2064,7 @@ ppfunction:
                 }
 
                 calleffects(player, target, "UponAttackSuccessful");
-                if (!hasSubstitute(target))
+                if (!sub)
                     calleffects(player, target, "OnFoeOnAttack");
 
                 healDamage(player, target);
@@ -2112,7 +2112,7 @@ ppfunction:
                 notifyHits(player, hitcount);
             }
 
-            if (gen() >= 5 && !koed(target) && !hasSubstitute(target)) {
+            if (gen() >= 5 && !koed(target) && !sub) {
                 callaeffects(target, player, "AfterBeingPlumetted");
             }
 


### PR DESCRIPTION
And ability effects, etc.

Before, with an ability that ignored substitute or sound moves, the effects that would be blocked by a substitute (flinch, ...) would still be blocked.

There's probably still some stuff still blocked, but a lot of it is fixed here.