### PR TITLE
Remove PM change name event option

### DIFF
--- a/src/Teambuilder/client.cpp
+++ b/src/Teambuilder/client.cpp
@@ -888,10 +888,6 @@ void Client::togglePMLogs(bool b) {
     LogManager::obj()->changeLogSaving(PMLog, b);
 }
 
-void Client::toggleChangeNamePM(bool b) {
-    globals.setValue("PMs/ChangeNameEvents", b);
-}
-
 void Client::ignoreServerVersion(bool b)
 {
     QString key  = QString("ignore_version_%1_%2").arg(serverVersion.version).arg(serverVersion.subversion);
@@ -1398,11 +1394,6 @@ QMenuBar * Client::createMenuBar(MainEngine *w)
     pm_reject->setCheckable(true);
     connect(pm_reject, SIGNAL(triggered(bool)), SLOT(toggleIncomingPM(bool)));
     pm_reject->setChecked(globals.value("PMs/RejectIncoming").toBool());
-
-    QAction * pm_changename = pmMenu->addAction(tr("Enable change name message in PMs"));
-    pm_changename->setCheckable(true);
-    connect(pm_changename, SIGNAL(triggered(bool)), SLOT(toggleChangeNamePM(bool)));
-    pm_changename->setChecked(globals.value("PMs/ChangeNameEvent").toBool());
 
     QMenu * sortMenu = menuActions->addMenu(tr("&Sort players"));
 

--- a/src/Teambuilder/client.h
+++ b/src/Teambuilder/client.h
@@ -311,7 +311,6 @@ public slots:
     void togglePMTabs(bool);
     void togglePMNotifications(bool);
     void togglePMLogs(bool);
-    void toggleChangeNamePM(bool);
     void movePlayerList(bool);
     void useOldShortcuts(bool);
     void displayTrainerInfo(bool b);

--- a/src/Teambuilder/pmsystem.cpp
+++ b/src/Teambuilder/pmsystem.cpp
@@ -242,8 +242,7 @@ void PMStruct::emitCp()
 void PMStruct::changeName(const QString &newname)
 {
     QString oldname = name();
-    QSettings s;
-    if (s.value("PMs/ChangeNameEvents").toBool() && !oldname.isEmpty() && oldname != newname) {
+    if (!oldname.isEmpty() && oldname != newname) {
         printHtml(tr("%1 changed names and is now known as %2.").arg(oldname, newname));
     }
     this->m_name = newname;


### PR DESCRIPTION
I don't see a reason why someone would disable this feature, so I removing the option.
Opinions?