### PR TITLE
Move choice fix

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -1637,7 +1637,7 @@ void BattleSituation::useAttack(int player, int move, bool specialOccurence, boo
     turnMem(player).add(TM::HasPassedStatus);
 
     //Down here so it doesnt get overridden but still defines it before the announcement
-    if (zmoving && canBeZMove(player, attack)) {
+    if (zmoving && canBeZMove(player, attack) && isZMovePossible(player, attack)) {
         zmoves[this->player(player)] = true;
         sendItemMessage(68, player);
         if (tmove(player).power > 0 && attack != Move::MeFirst) {

--- a/src/libraries/PokemonInfo/battlestructs.cpp
+++ b/src/libraries/PokemonInfo/battlestructs.cpp
@@ -1027,7 +1027,7 @@ bool BattleChoice::match(const BattleChoices &avail) const
                 //Crash attempt!!
                 return false;
             }
-            if (avail.zmove) {
+            if (zmove() && avail.zmove) {
                 return avail.zmoveAllowed[attackSlot()];
             }
             return avail.attackAllowed[attackSlot()];


### PR DESCRIPTION
Was preventing choice of moves of different type from z-crystal, even when z-move wasn't being used that turn.