### PR TITLE
Fix Pokemon reset on gen change

### DIFF
--- a/src/Teambuilder/Teambuilder/teambuilder.cpp
+++ b/src/Teambuilder/Teambuilder/teambuilder.cpp
@@ -180,10 +180,7 @@ void TeamBuilder::genChanged()
 
     for (int i = 0; i < 6; i++) {
         team().team().poke(i).load();
-        if (team().team().hackMons() == "false" || team().team().poke(i).isLegal()) {
-            team().team().poke(i).illegal() = false;
-            team().team().poke(i).runCheck();
-        }
+        team().team().poke(i).runCheck(team().team().hackMons() == "true");
     }
 
     markAllUpdated();

--- a/src/libraries/PokemonInfo/pokemonstructs.cpp
+++ b/src/libraries/PokemonInfo/pokemonstructs.cpp
@@ -207,6 +207,11 @@ bool PokePersonal::isLegal() const
     if (!PokemonInfo::Exists(num(), gen())) {
         return false;
     }
+    for (int i = 0; i < 4; i++) {
+        if (!MoveInfo::Exists(move(i), gen())) {
+            return false;
+        }
+    }
     if (PokemonInfo::IsForme(num()) && !PokemonInfo::AFormesShown(num())) {
         return false;
     }
@@ -247,6 +252,11 @@ void PokePersonal::runCheck(bool hack)
     if (!PokemonInfo::Exists(num(), gen())) {
         reset();
         return;
+    }
+    for (int i = 0; i < 4; i++) {
+        if (!MoveInfo::Exists(move(i), gen())) {
+            setMove(0, i, false);
+        }
     }
     if (hack) {
         return;


### PR DESCRIPTION
This sets pokemon and moves to 0 if they dont exist in the target gen. I'm just confused how this wasn't a problem before because the commit that added the check for hackmons and islegal was in April 2015.