### PR TITLE
Fix Genesis Supernova

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -8196,7 +8196,7 @@ struct MMZHealSwitch : public MM
 struct MMZSupernova : public MM
 {
     MMZSupernova() {
-        functions["AfterAttackFinished"] = &zm;
+        functions["AfterAttackSuccessful"] = &zm;
     }
 
     static void zm(int s, int, BS &b) {


### PR DESCRIPTION
No Psychic Terrain should be created when the move fails (e.g. opponent
is immune to Psychic-type moves)