### PR TITLE
Adapt turn order and recalculations of megas to gen 7

### DIFF
--- a/src/BattleServer/battle.h
+++ b/src/BattleServer/battle.h
@@ -20,6 +20,7 @@ class BattleSituation : public BattleBase
     Q_OBJECT
 public:
     typedef QVariantHash context;
+    typedef std::map<int, std::vector<int>, std::greater<int> > priority_order;
 
     BattleSituation(const BattlePlayer &p1, const BattlePlayer &p2, const ChallengeInfo &additionnalData, int id, const TeamBattle &t1, const TeamBattle &t2, BattleServerPluginManager *p);
     ~BattleSituation();
@@ -32,6 +33,8 @@ public:
     void analyzeChoice(int player);
     void analyzeChoices(); 
     std::vector<int> sortedBySpeed(std::vector<std::pair<int,int>> speeds = std::vector<std::pair<int,int>>());
+    priority_order calculatePriorities(const std::vector<int> &originalOrder, bool afterMegas);
+    std::vector<int> calculateFinalOrder(const priority_order &priorities);
 
     /* Commands for the battle situation */
     void engageBattle();
@@ -57,6 +60,7 @@ public:
     void sendBack(int player, bool silent = false);
     void shiftSpots(int spot1, int spot2, bool silent = false);
     bool megaEvolve(int spot);
+    bool justMegaEvolved(int spot) const;
     void useZMove(int spot);
     void sendPoke(int player, int poke, bool silent = false);
     void callEntryEffects(int player);

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -1373,6 +1373,7 @@ std::vector<std::pair<int, int> > BattleBase::calculateSpeeds()
     return speeds;
 }
 
+
 bool BattleBase::attacking() const
 {
     return attacker() != -1;

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -8019,7 +8019,7 @@ struct MMAbilityIgnore : public MM
         functions["BeforeHitting"] = &bh;
     }
 
-    static void bh(int s, int t, BS &b) {
+    static void bh(int, int t, BS &b) {
         if (AbilityInfo::moldBreakable(b.ability(t))) {
             //b.sendMoveMessage(239,0,s,type(b,s),t);
         }


### PR DESCRIPTION
I put some code into functions.

I also fixed a bug with truant & mega in doubles.

And should be correct turn order for megas, with their speed and priority recalculated after megaevolving, and only theirs.