### PR TITLE
ZMove bans

### DIFF
--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -975,6 +975,9 @@ bool BattleBase::validChoice(const BattleChoice &b)
         return true;
     }
 
+    int move = this->move(player, b.attackSlot());
+    int item = this->poke(b.slot()).item();
+
     if (b.attackingChoice()){
         /* It's an attack, we check the target is valid */
         if (b.target() < 0 || b.target() >= numberOfSlots())
@@ -997,6 +1000,9 @@ bool BattleBase::validChoice(const BattleChoice &b)
                         && choice(i).zmove()) {
                     return false;
                 }
+            }
+            if (bannedZMoves.contains(move) && item >= 3000 && item <= 3017) {
+                return false;
             }
         }
         return true;

--- a/src/BattleServer/battlebase.cpp
+++ b/src/BattleServer/battlebase.cpp
@@ -36,6 +36,7 @@ void BattleBase::init(const BattlePlayer &p1, const BattlePlayer &p2, const Chal
     restricted[1] = p2.restrictedPokes;
     bannedPokes[0] = p1.bannedPokes.split(", ");
     bannedPokes[1] = p2.bannedPokes.split(", ");
+    bannedZMoves = p1.bannedZMoves.split(", ");
     ratings[0] = p1.rating;
     ratings[1] = p2.rating;
     winMessage[0] = p1.win;
@@ -975,7 +976,7 @@ bool BattleBase::validChoice(const BattleChoice &b)
         return true;
     }
 
-    int move = this->move(player, b.attackSlot());
+    QString move = MoveInfo::Name(this->move(player, b.attackSlot()));
     int item = this->poke(b.slot()).item();
 
     if (b.attackingChoice()){

--- a/src/BattleServer/battlebase.h
+++ b/src/BattleServer/battlebase.h
@@ -189,7 +189,7 @@ protected:
     QString loseMessage[2];
     QString tieMessage[2];
     QStringList bannedPokes[2];
-    QList<int> bannedZMoves;
+    QStringList bannedZMoves;
     bool allowIllegal;
 
     /* timers */

--- a/src/BattleServer/battlebase.h
+++ b/src/BattleServer/battlebase.h
@@ -189,6 +189,7 @@ protected:
     QString loseMessage[2];
     QString tieMessage[2];
     QStringList bannedPokes[2];
+    QList<int> bannedZMoves;
     bool allowIllegal;
 
     /* timers */

--- a/src/Server/battlecommunicator.cpp
+++ b/src/Server/battlecommunicator.cpp
@@ -62,9 +62,9 @@ void BattleCommunicator::startBattle(Player *p1, Player *p2, const ChallengeInfo
         Tier & t = TierMachine::obj()->tier(tier);
 
         BattlePlayer pb1(p1->name(), p1->id(), p1->rating(team1.tier), p1->avatar(), p1->winningMessage(), p1->losingMessage(),
-                         p1->tieMessage(), t.getMaxLevel(), t.restricted(team1), t.maxRestrictedPokes, t.numberOfPokemons, t.getBannedPokes(), t.allowIllegal == "true");
+                         p1->tieMessage(), t.getMaxLevel(), t.restricted(team1), t.maxRestrictedPokes, t.numberOfPokemons, t.getBannedPokes(), t.allowIllegal == "true", t.getBannedZMoves());
         BattlePlayer pb2(p2->name(), p2->id(), p2->rating(team2.tier), p2->avatar(), p2->winningMessage(), p2->losingMessage(),
-                         p2->tieMessage(), t.getMaxLevel(), t.restricted(team2), t.maxRestrictedPokes, t.numberOfPokemons, t.getBannedPokes(), t.allowIllegal == "true");
+                         p2->tieMessage(), t.getMaxLevel(), t.restricted(team2), t.maxRestrictedPokes, t.numberOfPokemons, t.getBannedPokes(), t.allowIllegal == "true", t.getBannedZMoves());
         relay->startBattle(id, pb1, pb2, c, team1, team2);
     } else {
         BattlePlayer pb1(p1->name(), p1->id(), p1->rating(team1.tier), p1->avatar(), p1->winningMessage(), p1->losingMessage(),

--- a/src/Server/battlecommunicator.cpp
+++ b/src/Server/battlecommunicator.cpp
@@ -62,9 +62,9 @@ void BattleCommunicator::startBattle(Player *p1, Player *p2, const ChallengeInfo
         Tier & t = TierMachine::obj()->tier(tier);
 
         BattlePlayer pb1(p1->name(), p1->id(), p1->rating(team1.tier), p1->avatar(), p1->winningMessage(), p1->losingMessage(),
-                         p1->tieMessage(), t.getMaxLevel(), t.restricted(team1), t.maxRestrictedPokes, t.numberOfPokemons, t.getBannedPokes(), t.allowIllegal == "true", t.getBannedZMoves());
+                         p1->tieMessage(), t.getMaxLevel(), t.restricted(team1), t.maxRestrictedPokes, t.numberOfPokemons, t.getBannedPokes(), t.allowIllegal == "true", t.getBannedZMoves(true));
         BattlePlayer pb2(p2->name(), p2->id(), p2->rating(team2.tier), p2->avatar(), p2->winningMessage(), p2->losingMessage(),
-                         p2->tieMessage(), t.getMaxLevel(), t.restricted(team2), t.maxRestrictedPokes, t.numberOfPokemons, t.getBannedPokes(), t.allowIllegal == "true", t.getBannedZMoves());
+                         p2->tieMessage(), t.getMaxLevel(), t.restricted(team2), t.maxRestrictedPokes, t.numberOfPokemons, t.getBannedPokes(), t.allowIllegal == "true", t.getBannedZMoves(true));
         relay->startBattle(id, pb1, pb2, c, team1, team2);
     } else {
         BattlePlayer pb1(p1->name(), p1->id(), p1->rating(team1.tier), p1->avatar(), p1->winningMessage(), p1->losingMessage(),

--- a/src/Server/tier.cpp
+++ b/src/Server/tier.cpp
@@ -940,6 +940,7 @@ void Tier::loadFromXml(const QDomElement &elem)
     last_count_time = 0;
 
     importBannedMoves(elem.attribute("moves"));
+    importBannedZMoves(elem.attribute("zmoves"));
     importBannedItems(elem.attribute("items"));
     importBannedPokes(elem.attribute("pokemons"));
     importBannedAbilities(elem.attribute("abilities", ""));
@@ -1027,6 +1028,7 @@ QDomElement & Tier::toXml(QDomElement &dest) const {
     dest.setAttribute("mode", mode);
     dest.setAttribute("displayOrder", displayOrder);
     dest.setAttribute("moves", getBannedMoves());
+    dest.setAttribute("zmoves", getBannedZMoves());
     dest.setAttribute("items", getBannedItems());
     dest.setAttribute("abilities", getBannedAbilities());
     dest.setAttribute("pokemons", getBannedPokes());
@@ -1105,6 +1107,16 @@ QString Tier::getBannedMoves() const
     return bannedMovesS.join(", ");
 }
 
+QString Tier::getBannedZMoves() const
+{
+    QStringList bannedZMovesS;
+    foreach(int zmove, bannedZMoves) {
+        bannedZMovesS.append(MoveInfo::Name(zmove));
+    }
+    bannedZMovesS.sort();
+    return bannedZMovesS.join(", ");
+}
+
 QString Tier::getBannedAbilities() const
 {
     QStringList bannedAbilitiesS;
@@ -1172,6 +1184,20 @@ void Tier::importBannedMoves(const QString &s)
 
         if (num != 0)
             bannedMoves.insert(num);
+    }
+}
+
+void Tier::importBannedZMoves(const QString &s)
+{
+    bannedZMoves.clear();
+    if (s.length() == 0)
+        return;
+    QStringList zmoves = s.split(",");
+    foreach(QString zmove, zmoves) {
+        int num = MoveInfo::Number(zmove.trimmed());
+
+        if (num != 0)
+            bannedZMoves.insert(num);
     }
 }
 
@@ -1347,6 +1373,7 @@ Tier *Tier::dataClone() const
     t.banParentS = banParentS;
     t.bannedItems = bannedItems;
     t.bannedMoves = bannedMoves;
+    t.bannedZMoves = bannedZMoves;
     t.bannedAbilities = bannedAbilities;
     t.bannedPokes = bannedPokes;
     t.restrictedPokes = restrictedPokes;

--- a/src/Server/tier.cpp
+++ b/src/Server/tier.cpp
@@ -1107,11 +1107,14 @@ QString Tier::getBannedMoves() const
     return bannedMovesS.join(", ");
 }
 
-QString Tier::getBannedZMoves() const
+QString Tier::getBannedZMoves(bool parentNeeded) const
 {
     QStringList bannedZMovesS;
     foreach(int zmove, bannedZMoves) {
         bannedZMovesS.append(MoveInfo::Name(zmove));
+    }
+    if (parent && parentNeeded) {
+        bannedZMovesS.append(parent->getBannedZMoves());
     }
     bannedZMovesS.sort();
     return bannedZMovesS.join(", ");

--- a/src/Server/tier.h
+++ b/src/Server/tier.h
@@ -126,7 +126,7 @@ public:
     QString getBannedPokes(bool parentNeeded = false) const;
     QString getRestrictedPokes() const;
     QString getBannedMoves() const;
-    QString getBannedZMoves() const;
+    QString getBannedZMoves(bool parentNeeded = false) const;
     QString getBannedItems() const;
     QString getBannedAbilities() const;
     int getGeneration();

--- a/src/Server/tier.h
+++ b/src/Server/tier.h
@@ -126,6 +126,7 @@ public:
     QString getBannedPokes(bool parentNeeded = false) const;
     QString getRestrictedPokes() const;
     QString getBannedMoves() const;
+    QString getBannedZMoves() const;
     QString getBannedItems() const;
     QString getBannedAbilities() const;
     int getGeneration();
@@ -133,6 +134,7 @@ public:
     void importBannedPokes(const QString &);
     void importRestrictedPokes(const QString &);
     void importBannedMoves(const QString &);
+    void importBannedZMoves(const QString &);
     void importBannedItems(const QString &);
     void importBannedAbilities(const QString &);
 
@@ -196,6 +198,7 @@ private:
     Tier *parent;
     QSet<int> bannedItems;
     QSet<int> bannedMoves;
+    QSet<int> bannedZMoves;
     QSet<int> bannedAbilities;
     QSet<Pokemon::uniqueId> bannedPokes;
     QSet<Pokemon::uniqueId> restrictedPokes;

--- a/src/Server/tierwindow.cpp
+++ b/src/Server/tierwindow.cpp
@@ -159,6 +159,7 @@ void TierWindow::openTierEdit(Tier *t)
     helper->addConfigHelper(new ConfigSpin("Max number of pokemon", t->numberOfPokemons, 1, 6));
     helper->addConfigHelper(new ConfigLine("Pokemon", pokemons));
     helper->addConfigHelper(new ConfigLine("Moves", moves));
+    helper->addConfigHelper(new ConfigLine("ZMoves", zmoves));
     helper->addConfigHelper(new ConfigLine("Items", items));
     helper->addConfigHelper(new ConfigLine("Abilities", abilities));
     helper->addConfigHelper(new ConfigSpin("Max number of restricted pokemon", t->maxRestrictedPokes, 0, 6));
@@ -167,6 +168,7 @@ void TierWindow::openTierEdit(Tier *t)
 
     pokemons = t->getBannedPokes();
     moves = t->getBannedMoves();
+    zmoves = t->getBannedZMoves();
     items = t->getBannedItems();
     abilities = t->getBannedAbilities();
     restrPokemons = t->getRestrictedPokes();
@@ -274,6 +276,7 @@ void TierWindow::updateTier()
     currentTier->importBannedItems(items);
     currentTier->importBannedPokes(pokemons);
     currentTier->importBannedMoves(moves);
+    currentTier->importBannedZMoves(zmoves);
     currentTier->importBannedAbilities(abilities);
     currentTier->importRestrictedPokes(restrPokemons);
 

--- a/src/Server/tierwindow.h
+++ b/src/Server/tierwindow.h
@@ -45,7 +45,7 @@ private:
     void clearCurrentEdit();
     /* Data used to configure categories / tiers */
     QString parent;
-    QString pokemons, restrPokemons, moves, items, abilities;
+    QString pokemons, restrPokemons, moves, zmoves, items, abilities;
     TierCategory *currentTierCat;
     Tier *currentTier;
     Type currentType;

--- a/src/libraries/PokemonInfo/battlestructs.cpp
+++ b/src/libraries/PokemonInfo/battlestructs.cpp
@@ -1130,12 +1130,12 @@ DataStream & operator << (DataStream &out, const ChallengeInfo & c) {
 }
 
 DataStream & operator >> (DataStream &in, BattlePlayer & c) {
-    in >> c.id >> c.name >> c.avatar >> c.rating >> c.win >> c.lose >> c.tie >> c.restrictedCount >> c.restrictedPokes >> c.teamCount >> c.maxlevel >> c.bannedPokes >> c.allowIllegal;
+    in >> c.id >> c.name >> c.avatar >> c.rating >> c.win >> c.lose >> c.tie >> c.restrictedCount >> c.restrictedPokes >> c.teamCount >> c.maxlevel >> c.bannedPokes >> c.allowIllegal >> c.bannedZMoves;
     return in;
 }
 
 DataStream & operator << (DataStream &out, const BattlePlayer & c) {
-    out << c.id << c.name << c.avatar << c.rating << c.win << c.lose << c.tie << c.restrictedCount << c.restrictedPokes << c.teamCount << c.maxlevel << c.bannedPokes << c.allowIllegal;
+    out << c.id << c.name << c.avatar << c.rating << c.win << c.lose << c.tie << c.restrictedCount << c.restrictedPokes << c.teamCount << c.maxlevel << c.bannedPokes << c.allowIllegal << c.bannedZMoves;
     return out;
 }
 

--- a/src/libraries/PokemonInfo/battlestructs.h
+++ b/src/libraries/PokemonInfo/battlestructs.h
@@ -575,11 +575,12 @@ struct BattlePlayer
     quint8 teamCount;
     QString bannedPokes;
     bool allowIllegal;
+    QString bannedZMoves;
     BattlePlayer(){}
     BattlePlayer(const QString &name, int id, int rating=0, int avatar=0, const QString &win="", const QString &lose="",
-                 const QString &tie="", int maxlevel=100, int restrictedPokes=0, int restrictedCount=0, int teamCount=6, const QString &bannedPokes="", bool allowIllegal = false)
+                 const QString &tie="", int maxlevel=100, int restrictedPokes=0, int restrictedCount=0, int teamCount=6, const QString &bannedPokes="", bool allowIllegal = false, const QString &bannedZMoves="")
         : name(name), win(win), lose(lose), tie(tie), rating(rating), avatar(avatar), id(id), maxlevel(maxlevel),
-          restrictedPokes(restrictedPokes), restrictedCount(restrictedCount), teamCount(teamCount), bannedPokes(bannedPokes), allowIllegal(allowIllegal){}
+          restrictedPokes(restrictedPokes), restrictedCount(restrictedCount), teamCount(teamCount), bannedPokes(bannedPokes), allowIllegal(allowIllegal), bannedZMoves(bannedZMoves){}
 };
 
 DataStream & operator >> (DataStream &in, BattlePlayer &p);


### PR DESCRIPTION
Allows us to ban the zform of a base move (eg If Detect is in bannedZMoves then you can choose Detect, but if you try to use Z-Detect then it will be an invalid choice). For unique ZMoves you can ban the corresponding item.