### PR TITLE
Fixed alwaysOnTop bug when compiled with Qt 5.2.1

### DIFF
--- a/src/Teambuilder/BattleWindow/basebattlewindow.cpp
+++ b/src/Teambuilder/BattleWindow/basebattlewindow.cpp
@@ -59,6 +59,7 @@ void BaseBattleWindow::init(const PlayerInfo &me, const PlayerInfo &opponent, co
 
     init();
     show();
+    alwaysOnTopChanged(alwaysOnTop->isChecked());
 }
 
 BaseBattleWindow::BaseBattleWindow()
@@ -197,7 +198,6 @@ void BaseBattleWindow::init()
 
     musicPlayStop();
     criesPlayStop();
-    alwaysOnTopChanged(alwaysOnTop->isChecked());
 }
 
 bool BaseBattleWindow::musicPlayed() const


### PR DESCRIPTION
Environment:
Qt 5.2.1
Ubuntu 16.04

I compiled po with Qt 4.8, 5.0, 5.1, 5.2, 5.5, 5.7. And Qt 5.2 is the only version worked well under Ubuntu, while other versions are either buggy or not support Chinese input. But there are still some problems, one is alwayOnTop not worked correctly. And I fixed it.