### PR TITLE
Fix HP selection in Gen 7

### DIFF
--- a/src/libraries/PokemonInfo/pokemonstructs.cpp
+++ b/src/libraries/PokemonInfo/pokemonstructs.cpp
@@ -349,7 +349,7 @@ bool PokePersonal::hasValidHiddenPower() const
       }
       minPossible = (minPossible*15)/63 + 1;
       maxPossible = (maxPossible*15)/63 + 1;
-      return (maxPossible < hiddenPower() || hiddenPower() < minPossible);
+      return !(maxPossible < hiddenPower() || hiddenPower() < minPossible);
   }
   return hiddenPower() == HiddenPowerInfo::Type(gen().num, DV(0), DV(1), DV(2), DV(3), DV(4), DV(5));
 }


### PR DESCRIPTION
Fixes a regression from [this commit](https://github.com/po-devs/pokemon-online/commit/4b57d6c8beb0ba153a71bff713bff8a405336072) that prevented HP selection from working. 