### PR TITLE
Fix Iapapa berry not working

### DIFF
--- a/bin/db/items/berry_effects.txt
+++ b/bin/db/items/berry_effects.txt
@@ -13,7 +13,7 @@
 12 13-3#Wiki--Adamant, Careful, Impish, Jolly (-SpA)
 13 13-5#Mago--Brave, Quiet, Relaxed, Sassy (-Spe)
 14 13-4#Aguav--Lax, Naive, Naughty, Rash (-SpDef)
-35 13-2#Iapapa---Gentle, Hasty, Lonely, Mild (-Def)
+15 13-2#Iapapa--Gentle, Hasty, Lonely, Mild (-Def)
 36 4-9
 37 4-10
 38 4-12


### PR DESCRIPTION
Iapapa is No.15, not 35. Someone must have deleted 15-34 instead of 16-35 when building this file, and no one found this until then lol.