### PR TITLE
Various hidden power fixes

### DIFF
--- a/src/Server/tiermachine.cpp
+++ b/src/Server/tiermachine.cpp
@@ -240,11 +240,9 @@ bool TierMachine::isBanned(const PokeBattle &pok, const QString & tier) const
 
 void TierMachine::tierValidation(TeamBattle &t, const QString &name) const
 {
-    if (exists(name)) {
-        for (int i = 0; i < 6; i++)
-        {
-            tierValidation(t.poke(i), name);
-        }
+    for (int i = 0; i < 6; i++)
+    {
+        tierValidation(t.poke(i), name);
     }
 }
 
@@ -254,28 +252,17 @@ void TierMachine::tierValidation(PokeBattle &pok, const QString &name) const
         return;
     }
 
-    Tier *t = this->tier(name).dataClone();
+    if (!exists(name)) {
+        if (pok.level() < 100 && pok.gen() >= 7) {
+            pok.forceMatchHiddenPowerIV();
+        }
+    } else {
+        Tier *t = this->tier(name).dataClone();
 
-    if (t->gen() > 6) {
-        //change ivs to match hp instead for android friendliness
-        if (t->maxLevel == 5 || pok.level() < t->maxLevel) {
-            if (pok.hiddenPower() != HiddenPowerInfo::Type(pok.gen(), pok.dvs().at(0), pok.dvs().at(1), pok.dvs().at(2), pok.dvs().at(3), pok.dvs().at(4), pok.dvs().at(5))) {
-                //gen 6/7 legend can't have hp fighting
-                if (pok.hiddenPower() == Type::Fighting && ((pok.num().pokenum >= Pokemon::Xerneas && pok.num().pokenum <= Pokemon::Volcanion) || (pok.num().pokenum >= Pokemon::Tapu_Koko && pok.num().pokenum <= Pokemon::Marshadow))) {
-                    pok.hiddenPower() = HiddenPowerInfo::Type(pok.gen(), pok.dvs().at(0), pok.dvs().at(1), pok.dvs().at(2), pok.dvs().at(3), pok.dvs().at(4), pok.dvs().at(5));
-                } else {
-                    QStringList dvs;
-                    //gen 6/7 have at least 3 ivs be 31
-                    if ((pok.hiddenPower() == Type::Flying || pok.hiddenPower() == Type::Poison || pok.hiddenPower() == Type::Rock) && ((pok.num().pokenum >= Pokemon::Xerneas && pok.num().pokenum <= Pokemon::Volcanion) || (pok.num().pokenum >= Pokemon::Tapu_Koko && pok.num().pokenum <= Pokemon::Marshadow))) {
-                        dvs = HiddenPowerInfo::PossibilitiesForType(pok.hiddenPower(), pok.gen()).at(1);
-                    } else {
-                        dvs = HiddenPowerInfo::PossibilitiesForType(pok.hiddenPower(), pok.gen()).at(0);
-                    }
-                    pok.dvs().clear();
-                    for (int i = 0; i < 6; i++) {
-                        pok.dvs() << dvs.at(i).toInt();
-                    }
-                }
+        if (t->gen() >= 7) {
+            //change ivs to match hp instead for android friendliness
+            if (t->maxLevel == 5 || pok.level() < t->maxLevel) {
+                pok.forceMatchHiddenPowerIV();
             }
         }
     }

--- a/src/Teambuilder/Teambuilder/ivbox.cpp
+++ b/src/Teambuilder/Teambuilder/ivbox.cpp
@@ -171,7 +171,7 @@ void IvBox::updateIV(int stat)
 
 void IvBox::updateHiddenPower()
 {
-    if (poke().gen() >= 7 && poke().hasValidHiddenPower() && poke().level() == 100) {
+    if (poke().gen() >= 7 && poke().hasValidHiddenPower()) {
         ui->hiddenPowerType->setCurrentIndex(poke().hiddenPower() - 1);
         updateHiddenPowerSelection();
         return;
@@ -187,7 +187,7 @@ void IvBox::updateHiddenPower()
 void IvBox::updateHiddenPowerSelection()
 {
     QList<QStringList> possibilities;
-    if (poke().gen() >= 7 && poke().level() == 100) {
+    if (poke().gen() >= 7) {
         possibilities = HiddenPowerInfo::PossibilitiesForType(poke().hiddenPower(), poke().gen());
     } else {
         possibilities = HiddenPowerInfo::PossibilitiesForType(calculateHiddenPowerType(), poke().gen());
@@ -236,7 +236,7 @@ void IvBox::changeHiddenPower(int newType)
         return;
     }
 
-    if (poke().gen() >= 7 && poke().level() == 100) {
+    if (poke().gen() >= 7) {
         poke().setHiddenPower(newType);
         if (!poke().hasValidHiddenPower()) {
             QMessageBox::information(NULL, tr("Invalid Hidden Power"), tr("Cannot have Hidden Power type %1 with those IVs.").arg(TypeInfo::Name(poke().hiddenPower())));
@@ -268,14 +268,14 @@ void IvBox::changeHiddenPower(int newType)
             QMessageBox::information(NULL, tr("Impossible type"), tr("%1 can't have Hidden Power type %2.").arg(PokemonInfo::Name(poke().num().pokenum), ui->hiddenPowerType->currentText()));
             int type = calculateHiddenPowerType();
             ui->hiddenPowerType->setCurrentIndex(type - 1);
-            if (poke().gen() >= 7 && poke().level() == 100) {
+            if (poke().gen() >= 7) {
                 poke().setHiddenPower(type);
                 updateHiddenPowerSelection();
             }
             return;
         }
 
-        if (poke().gen() < 7 || poke().level() != 100) {
+        if (poke().gen() < 7) {
             QStringList possibility = possibilities.front();
 
             for (int i = 0; i < std::max(6, possibility.size()); i++) {

--- a/src/libraries/PokemonInfo/battlestructs.h
+++ b/src/libraries/PokemonInfo/battlestructs.h
@@ -114,6 +114,7 @@ public:
 
     quint16 normalStat(int stat) const;
     void updateStats(Pokemon::gen gen);
+    void forceMatchHiddenPowerIV();
 
     bool isFull() const { return lifePoints() == totalLifePoints(); }
     quint8 lifePercent() const { return lifePoints() == 0 ? 0 : std::max(1, lifePoints()*100/totalLifePoints());}

--- a/src/libraries/PokemonInfo/pokemonstructs.cpp
+++ b/src/libraries/PokemonInfo/pokemonstructs.cpp
@@ -258,7 +258,7 @@ void PokePersonal::runCheck(bool hack)
             setMove(0, i, false);
         }
     }
-    if (hiddenPower() < Type::Fighting || hiddenPower() >= Type::Dark) {
+    if (hiddenPower() < Type::Fighting || hiddenPower() > Type::Dark) {
       hiddenPower() = HiddenPowerInfo::Type(gen().num, DV(0), DV(1), DV(2), DV(3), DV(4), DV(5));
     }
     if (hack) {

--- a/src/libraries/PokemonInfo/pokemonstructs.cpp
+++ b/src/libraries/PokemonInfo/pokemonstructs.cpp
@@ -258,7 +258,7 @@ void PokePersonal::runCheck(bool hack)
             setMove(0, i, false);
         }
     }
-    if (hiddenPower() < 0 || hiddenPower() >= TypeInfo::NumberOfTypes()) {
+    if (hiddenPower() < Type::Fighting || hiddenPower() >= Type::Dark) {
       hiddenPower() = HiddenPowerInfo::Type(gen().num, DV(0), DV(1), DV(2), DV(3), DV(4), DV(5));
     }
     if (hack) {
@@ -338,7 +338,7 @@ void PokePersonal::runCheck(bool hack)
 bool PokePersonal::hasValidHiddenPower() const
 {
 
-  if (gen() >= 7 && level() == 100) {
+  if (gen() >= 7) {
         int minPossible = 0;
         int maxPossible = 0;
         for (int i = 0; i < 6; i++) {


### PR DESCRIPTION
Basic hidden power validations for all tiers.
Removed the level 100 check from team builder because it alters hidden power instead of IV and level "50" poke that were autoleveled in battle can hyper train.