### PR TITLE
Fix RevelationDance type overwritten (Untested P1)

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -7555,6 +7555,7 @@ struct MMRevelationDance : public MM
             tmove(b,s).type = Pokemon::Curse;
         } else {
             tmove(b,s).type = b.getType(s, 1);
+            turn(b, s)["RevelationDanceType"] = true;
         }
     }
 };


### PR DESCRIPTION
I mimic the way that fixed Judgment type overwritten. Storing true/false in dummy variable "RevelationDanceType" so we can reference it in abilities.cpp. 