### PR TITLE
Should fix Core Enforcer interaction with sub

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -8093,8 +8093,6 @@ struct MMCoreEnforcer : public MM
             return;
         if (poke(b,t).value("AbilityNullified").toBool())
             return;
-        if (b.hasSubstitute(t) && !b.canBypassSub(s))
-            return;
         int ability = b.ability(t);
         if (ability == Ability::Multitype || ability == Ability::RKSSystem || ability == Ability::Imposter || ability == Ability::StanceChange ||
                 ability == Ability::PowerConstruct || ability == Ability::BattleBond || ability == Ability::ZenMode ||


### PR DESCRIPTION
The ability nullifying effect bypasses substitute, and the damage hits sub just as other moves.