### PR TITLE
Sheer Force gen 7 moves

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -1702,10 +1702,12 @@ struct AMSheerForce : public AM
 
     static void btl(int s, int, BS &b) {
         int cl = tmove(b,s).classification;
+        int move = tmove(b,s).attack;
 
         /* Self stat changing moves like nitro charge/ancient power are boosted, but not moves like close combat/super power */
-        if (cl != Move::OffensiveStatChangingMove && cl != Move::OffensiveStatusInducingMove && tmove(b,s).flinchRate == 0
+        if ((cl != Move::OffensiveStatChangingMove && cl != Move::OffensiveStatusInducingMove && tmove(b,s).flinchRate == 0
             && (cl != Move::OffensiveSelfStatChangingMove || ((signed char)(tmove(b,s).boostOfStat >> 16)) < 0))
+            && !(move == Move::AnchorShot || move == Move::GenesisSupernova || move == Move::SparklingAria || move == Move::SpiritShackle || move == Move::ThroatChop))
             return;
 
         tmove(b,s).classification = Move::StandardMove;

--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -648,7 +648,7 @@ BattleChoices BattleSituation::createChoice(int spot)
 
     if (!hasWorkingItem(spot, Item::ShedShell) && (gen() < 6 || !hasType(spot, Type::Ghost))) {
         /* Shed Shell */
-        if ((!hasWorkingAbility(spot, Ability::ShieldDust) && linked(spot, "Blocked")) || linked(spot, "Trapped")) {
+        if (linked(spot, "Blocked") || linked(spot, "Trapped")) {
             ret.switchAllowed = false;
         }
 

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1094,6 +1094,8 @@ struct MMBlock : public MM
     }
 
     static void uas (int s, int t, BS &b) {
+        if ((b.hasWorkingAbility(t, Ability::AromaVeil) || b.hasWorkingAbility(s, Ability::SheerForce)) && (tmove(b,s).attack == Move::SpiritShackle || tmove(b,s).attack == Move::AnchorShot))
+
         if (!b.linked(t, "Blocked") && !b.koed(t)) {
             b.link(s, t, "Blocked");
             b.sendMoveMessage(12, 0, s, type(b,s), t);
@@ -5055,6 +5057,9 @@ struct MMSmellingSalt : public MM
 
     static void aas(int s, int t, BS &b) {
         if (!b.koed(t)) {
+            if (b.hasWorkingAbility(s, Ability::SheerForce) && tmove(b,s).attack == Move::SparklingAria)
+                return;
+
             int status = turn(b,s)["SmellingSalt_Arg"].toInt();
 
             /* Venom Shock doesn't heal, as well as Hex */
@@ -7635,7 +7640,9 @@ struct MMThroatChop : public MM //copied from taunt
         }
         if (b.hasWorkingAbility(t, Ability::ShieldDust))
             return;
-        
+        if (b.hasWorkingAbility(s, Ability::SheerForce))
+            return;
+
         b.sendMoveMessage(223,1,s,Pokemon::Dark,t);
         if (b.gen() >= 5 && b.hasWorkingItem(t, Item::MentalHerb)) /* mental herb*/ {
             b.sendItemMessage(7,t);
@@ -8236,6 +8243,9 @@ struct MMZSupernova : public MM
     }
 
     static void zm(int s, int, BS &b) {
+        if(b.hasWorkingAbility(s, Ability::SheerForce))
+            return;
+
         if(b.terrain != BS::PsychicTerrain) {
             b.sendMoveMessage(240,BS::PsychicTerrain - 1,s,type(b,s));
             b.coverField(BS::PsychicTerrain, (b.hasWorkingItem(s, Item::TerrainExtender) ? 8 : 5));

--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -1095,6 +1095,7 @@ struct MMBlock : public MM
 
     static void uas (int s, int t, BS &b) {
         if ((b.hasWorkingAbility(t, Ability::AromaVeil) || b.hasWorkingAbility(s, Ability::SheerForce)) && (tmove(b,s).attack == Move::SpiritShackle || tmove(b,s).attack == Move::AnchorShot))
+            return;
 
         if (!b.linked(t, "Blocked") && !b.koed(t)) {
             b.link(s, t, "Blocked");


### PR DESCRIPTION
Untested

I also changed the aroma veil for Block to only affect the two gen 7 moves and so that Pokemon can't switch out if they are blocked but gain aroma veil at a later time.