### PR TITLE
Correct Stamina behind a Sub behavior

### DIFF
--- a/src/BattleServer/abilities.cpp
+++ b/src/BattleServer/abilities.cpp
@@ -2581,7 +2581,7 @@ struct AMStamina : public AM {
     }
 
     static void uodr(int s, int t, BS &b) {
-        if (!b.koed(s) && s != t) { // copied from ability Anger Point
+        if (!b.koed(s) && s != t && (!(b.hasSubstitute(s)) || b.canBypassSub(t))) { // copied from ability Anger Point
             b.sendAbMessage(133,0,s);
             b.inflictStatMod(s, Defense, 1, s);
         }


### PR DESCRIPTION
Stamina should not activate when the substitute takes the damage.