### PR TITLE
Correct Core Enforcer on the switch behavior

### DIFF
--- a/src/BattleServer/moves.cpp
+++ b/src/BattleServer/moves.cpp
@@ -8111,7 +8111,7 @@ struct MMCoreEnforcer : public MM
     }
 
     static void uas(int s, int t, BS &b) {
-        if (!b.hasMoved(t))
+        if (!fturn(b,t).contains(TM::HasMoved))
             return;
         if (poke(b,t).value("AbilityNullified").toBool())
             return;


### PR DESCRIPTION
They recently figured out that Core Enforcer is just like Payback (in gen 7), i.e. no ability nullifying effect if target hit on the turn of the switch.
http://www.smogon.com/forums/threads/ultra-sun-ultra-moon-battle-mechanics-research-read-post-2.3620030/page-6#post-7614947