### PR TITLE
Fix old bugs

### DIFF
--- a/src/BattleServer/battle.cpp
+++ b/src/BattleServer/battle.cpp
@@ -3164,6 +3164,10 @@ QVector<int> BattleSituation::getTypes(int player, bool transform) const
 {
     QVector<int> ret;
 
+    if (fpoke(player).type1 == Type::Curse) { // fix the ??? bug
+        ret.push_back(Type::Curse);
+    }
+
     foreach(int type, fpoke(player).types) {
         if (type == Pokemon::Flying && pokeMemory(player).value("Roosted").toBool() && !transform) {
             continue;

--- a/src/Server/channel.h
+++ b/src/Server/channel.h
@@ -32,7 +32,7 @@ public:
     static bool validName(const QString &name);
     static QNickValidator *checker;
 
-    void log(const QString &message);
+    void log(int pid, const QString &message);
     void onRemoval();
 
     void warnAboutRemoval();
@@ -52,7 +52,9 @@ public:
     QSet<int> players;
     QSet<int> disconnectedPlayers;
     QHash<int, Battle> battleList;
+    QFile logfile;
     Server *server;
+    int logDay;
 };
 
 #endif // CHANNEL_H

--- a/src/Server/server.cpp
+++ b/src/Server/server.cpp
@@ -196,7 +196,7 @@ void Server::start(){
     for (int i = 0; i < serverPorts.size(); ++i) {
         quint16 port = serverPorts.at(i);
 #ifndef BOOST_SOCKETS
-        listenSuccess = server(i)->listen(QHostAddress::Any, port);
+        listenSuccess = server(i)->listen(QHostAddress::AnyIPv4, port);
 #else
         listenSuccess = server(i)->listen(port);
 #endif
@@ -1952,7 +1952,7 @@ void Server::broadCast(const QString &message, int channel, int sender, bool htm
     } else {
         if (channel != NoChannel) {
             if(useChannelFileLog) {
-                this->channel(channel).log(fullMessage);
+                this->channel(channel).log(sender, fullMessage);
             }
             printLine(QString("[#%1] %2").arg(this->channel(channel).name(), fullMessage), chatMessage, true);
             if (sender == NoSender) {

--- a/src/Server/serverwidget.cpp
+++ b/src/Server/serverwidget.cpp
@@ -191,6 +191,7 @@ void ServerWidget::openConfig()
     connect(w, SIGNAL(privacyChanged(bool)), server, SLOT(regPrivacyChanged(bool)));
     connect(w, SIGNAL(announcementChanged(QString)), server, SLOT(announcementChanged(QString)));
     connect(w, SIGNAL(logSavingChanged(bool)), server, SLOT(logSavingChanged(bool)));
+    connect(w, SIGNAL(useChannelFileLogChanged(bool)), server, SLOT(useChannelFileLogChanged(bool)));
     connect(w, SIGNAL(inactivePlayersDeleteDaysChanged(int)), server, SLOT(inactivePlayersDeleteDaysChanged(int)));
     connect(w, SIGNAL(mainChanChanged(QString)), server, SLOT(mainChanChanged(QString)));
     connect(w, SIGNAL(latencyChanged(bool)), server, SLOT(TCPDelayChanged(bool)));


### PR DESCRIPTION
These three commits fix three old bugs that have existed in PO for over a decade.

1. Fix channel logging not working. The server will now write log files for your channels again if it is enabled. Not only that, but the functionality has been improved so that it writes HTML files instead, improving log readability and making it possible to host them somewhere.
2. The effectiveness on the ??? type has been patched. Pokemon of only this type were accidentally treated like Normal-types, due to another bugfix that was intended to make the move Synchronoise work properly.
3. IP addresses are no longer prepended with `::ffff:` by the server. They are now stored in the database in the correct notation and will be shown as such everywhere.